### PR TITLE
Sg/2024 04 27

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -989,7 +989,7 @@ class PlacesDetailAPIView(View):
         # Aggregate places into a single object
         aggregated_place = {
             "id": "-".join(ids),  # Concatenate the IDs,
-            "traces": [trace for place in serialized_places for trace in place["traces"]], ################################## FIX THIS!!!!!!!!!!!!!!!!!!!!!!!!
+            "traces": [trace for place in serialized_places for trace in place["traces"]],
             "datasets": sort_unique(list(Dataset.objects.filter(id__in=dataset_ids).values("id", "title")), 'title'),
             "title": "|".join(set(place["title"] for place in serialized_places)),
             "names": sort_unique([name for place in serialized_places for name in place["names"]], 'toponym'),

--- a/collection/models.py
+++ b/collection/models.py
@@ -67,11 +67,11 @@ class Collection(models.Model):
       related_name='collections', on_delete=models.CASCADE)
   title = models.CharField(null=False, max_length=255)
   description = models.TextField(max_length=3000)
-  keywords = ArrayField(models.CharField(max_length=50), null=True)
+  keywords = ArrayField(models.CharField(max_length=50), null=True, default=list)
 
   # per-collection relation keyword choices, e.g. waypoint, birthplace, battle site
   # TODO: ?? need default or it errors for some reason
-  rel_keywords = ArrayField(models.CharField(max_length=30), blank=True, null=True)
+  rel_keywords = ArrayField(models.CharField(max_length=30), blank=True, null=True, default=list)
   # rel_keywords = ArrayField(models.CharField(max_length=30), blank=True, default=default_relations)
 
   # 3 new fields, 20210619

--- a/collection/templates/collection/ds_collection_browse.html
+++ b/collection/templates/collection/ds_collection_browse.html
@@ -60,12 +60,9 @@
           </div>
           <div class="col-sm-3" style="position: relative;">
             {% if object.image_file %}
-              <a href="#" class="pop">
                 <img id="active_img"
                      class="img-responsive thumbnail float-end"
-                     src="/media/{{ object.image_file.name }}"
-                     width="220px"/>
-              </a>
+                     src="/media/{{ object.image_file.name }}" />
             {% else %} <span><i>image here</i></span>
             {% endif %}
           </div>

--- a/collection/templates/collection/ds_collection_browse.html
+++ b/collection/templates/collection/ds_collection_browse.html
@@ -281,9 +281,10 @@
     }
   </script>
 
+  {{ object.vis_parameters|json_script:"vis_parameters_data" }}
   <script type="text/javascript">
     const pageData = "{{ object.id }}";
-    var visParameters = {{ visParameters|safe }};
+    var visParameters = JSON.parse(document.getElementById('vis_parameters_data').innerHTML);
     window.loggedin = "{{ loggedin }}";
     window.dslabel = "{{ object.label }}";
     window.filter = "{{ filter }}";

--- a/collection/templates/collection/place_collection_browse.html
+++ b/collection/templates/collection/place_collection_browse.html
@@ -59,7 +59,7 @@
           <div class="col-sm-3" style="position: relative;">
             {% if object.image_file %}
 				<img id="active_img" class="img-responsive thumbnail float-end"
-                   src="/media/{{ object.image_file.name }}" width="220px"/>
+                   src="/media/{{ object.image_file.name }}"/>
             {% else %}
             	<span><i>image here</i></span>
             {% endif %}

--- a/collection/templates/collection/place_collection_browse.html
+++ b/collection/templates/collection/place_collection_browse.html
@@ -57,18 +57,25 @@
             </p>
           </div>
           <div class="col-sm-3" style="position: relative;">
-            {% if object.image_file %} <a href="#" class="pop">
-              <img id="active_img" class="img-responsive thumbnail float-end"
+            {% if object.image_file %}
+				<img id="active_img" class="img-responsive thumbnail float-end"
                    src="/media/{{ object.image_file.name }}" width="220px"/>
-            </a> {% else %} <span>
-                      <i>image here</i>
-                  </span> {% endif %} </div>
+            {% else %}
+            	<span><i>image here</i></span>
+            {% endif %}
+          </div>
         </div>
         <div id="coll_detail">
           <table>
             <tr>
               <td><b>Keywords</b></td>
-              <td>{{ object.keywords|join:', ' }}</td>
+              <td>
+			    {% if object.keywords %}
+			        {{ object.keywords|join:', ' }}
+			    {% else %}
+			    	None
+			    {% endif %}
+              </td>
             </tr>
             {% if links|length > 0 %}
               <tr>
@@ -128,18 +135,7 @@
         <table id="placetable" class="table table-striped table-bordered small"
                style="width:100%"></table>
       </div>
-      <div id="detail" class="overlay right">
-        <div class="row">
-          <div class="col-sm-9">
-            <span id="anno_title" class="pub-anno-title"></span>
-            <div id="anno_body"></div>
-          </div>
-          <div id="" class="col-sm-3" style="position: relative;">
-            <img id="anno_img" class="img-dscoll thumbnail float-end"
-                 src="" width="100px"/>
-          </div>
-        </div>
-      </div>
+      <div id="detail" class="overlay right"></div>
       <div id="downloadModal" class="modal fade" tabindex="-1"
            aria-labelledby="downloadModalLabel" aria-hidden="true">
         <div class="modal-dialog modal-lg">
@@ -204,22 +200,6 @@
           </div>
         </div>
       </div>
-      <div id="imageModal" class="modal fade" tabindex="-1"
-           role="dialog" aria-hidden="true">
-        <div class="modal-dialog d-flex modal-custom">
-          <div class="modal-content flex-shrink-1 mx-auto h-auto w-auto ">
-            <div class="modal-header">
-              <span id="header_text"></span>
-              <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                <span aria-hidden="true">&times;</span>
-              </button>
-            </div>
-            <div class="modal-body">
-              <img src="" class="imagepreview" style="max-height: 600px;">
-            </div>
-          </div>
-        </div>
-      </div>
     </div>
   </div>
   <!-- pcoll_content -->
@@ -257,7 +237,6 @@
   <script type="text/javascript">
     const pageData = "{{ object.id }}";
     var visParameters = JSON.parse(document.getElementById('vis_parameters_data').innerHTML);
-    window.collimagepath = "{{ object.image_file.name }}"
     window.ds_list = [{
         ds_type: "collections",
         id: {{ object.id }},

--- a/collection/urls.py
+++ b/collection/urls.py
@@ -53,6 +53,7 @@ urlpatterns = [
     path('update_sequence/', views.update_sequence, name='update-sequence'),
 
     path('add_places/', views.add_places, name="collection-add-places"),
+    path('add_collection_places/', views.add_collection_places, name="add-collection-places"),
     path('archive_traces/', views.archive_traces, name="collection-archive_traces"),
     # path('create_link/', views.create_link, name="collection-create-link"),
     path('remove_link/<int:id>/', views.remove_link, name="remove-link"),

--- a/collection/views.py
+++ b/collection/views.py
@@ -10,6 +10,8 @@ import random
 from django import forms
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.db.models import F, Min, Max
+from django.db.models.functions import Coalesce
 from django.forms.models import inlineformset_factory
 from django.http import JsonResponse, HttpResponseRedirect, Http404
 from django.shortcuts import get_object_or_404, redirect
@@ -21,13 +23,16 @@ from django.contrib.gis.db.models import Extent
 from django.contrib.gis.db.models.aggregates import Union
 from django.contrib.gis.db.models.functions import Centroid
 
+from elastic.es_utils import findPortalPIDs
+
 from .forms import CollectionModelForm, CollectionGroupModelForm
 from .models import *
-from places.models import PlaceGeom
+from places.models import PlaceGeom, Place, CloseMatch
 from main.models import Log, Link
 from traces.forms import TraceAnnotationModelForm
 from traces.models import TraceAnnotation
 from array import array
+from itertools import chain
 
 """ collection group joiner"; prevent duplicate """
 def join_group(request, *args, **kwargs):
@@ -416,91 +421,202 @@ def year_from_string(ts):
 
 # GeoJSON for all places in a collection INCLUDING those without geometry
 def fetch_mapdata_coll(request, *args, **kwargs):
-  from django.core.serializers import serialize
-  from django.db.models import Min, Max
-  print('fetch_geojson_coll kwargs',kwargs)
-  id_=kwargs['id']
-  coll=get_object_or_404(Collection, id=id_)
+    
+    from django.core.serializers import serialize
+    from django.db.models import Min, Max
+    import networkx as nx
+    print('fetch_geojson_coll kwargs', kwargs)
+    id_ = kwargs['id']
+    coll = get_object_or_404(Collection, id=id_)
 
-  rel_keywords = coll.rel_keywords
+    tileset = request.GET.get('variant', '') == 'tileset'
+    ignore_tilesets = request.GET.get('variant', '') == 'ignore_tilesets'
+    
+    ############################################################################################################
+    # TODO: Force `ignore_tilesets` if any `visParameters` object has 'trail: true'                            #
+    # (representative points have to be generated in the browser)                                              #
+    ############################################################################################################
 
-  tileset = request.GET.get('variant', '') == 'tileset'
-  ignore_tilesets = request.GET.get('variant', '') == 'ignore_tilesets'
+    available_tilesets = None
+    null_geometry = False
+    if not tileset and not ignore_tilesets:
+        tiler_url = os.environ.get('TILER_URL')  # Must be set in /.env/.dev-whg3
+        response = requests.post(tiler_url, json={"getTilesets": {"type": "collections", "id": id_}})
 
-  if coll.collection_class == 'dataset':
-    # Divert to fetch_mapdata_dscoll
-    return fetch_mapdata_dscoll(id_, coll, tileset, ignore_tilesets)
+        if response.status_code == 200:
+            available_tilesets = response.json().get('tilesets', [])
+            null_geometry = len(available_tilesets) > 0
+    
+    if coll.collection_class == 'place':
+        traces_with_place_ids = coll.traces.filter(archived=False).annotate(annotated_place_id=F('place__id'))
+        unique_place_ids = traces_with_place_ids.values_list('annotated_place_id', flat=True).distinct()
+        coll_places_all = Place.objects.filter(id__in=unique_place_ids)
+    else:
+        coll_places_all = coll.places_all
 
-  ############################################################################################################
-  # TODO: Force `ignore_tilesets` if any `visParameters` object has 'trail: true'                            #
-  # (representative points have to be generated in the browser)                                              #
-  ############################################################################################################
+    extent = list(coll_places_all.aggregate(Extent('geoms__geom')).values())[0]
 
-  available_tilesets = None
-  null_geometry = False
-  if not tileset and not ignore_tilesets:
-
-    tiler_url = os.environ.get('TILER_URL') # Must be set in /.env/.dev-whg3
-    response = requests.post(tiler_url, json={"getTilesets": {"type": "collections", "id": id_}})
-
-    if response.status_code == 200:
-        available_tilesets = response.json().get('tilesets', [])
-        null_geometry = len(available_tilesets) > 0
-
-  extent = list(coll.places_all.aggregate(Extent('geoms__geom')).values())[0]
-
-  annotated_places = coll.places_all.annotate(seq=Min('annos__sequence')).order_by('seq')
-
-  feature_collection = {
-    "title": coll.title,
-    "creator": coll.creator,
-    "type": "FeatureCollection",
-    "features": [],
-    "relations": coll.rel_keywords,
-    "extent": extent,
-  }
-
-  if null_geometry:
-    feature_collection["tilesets"] = available_tilesets
-
-  for i, t in enumerate(coll.traces.filter(archived=False)):
-    # Get the first annotation's sequence value
-    first_anno = t.place.annos.first()
-    sequence_value = first_anno.sequence if first_anno else None
-
-    geoms = t.place.geoms.all()
-    geometry = t.place.geoms.all()[0].jsonb if geoms else None # some places have no geometry
-
-    feature = {
-          "type": "Feature",
-          "geometry": geometry,
-          "properties": {
-              "pid": t.place.id,
-              "cid": id_,
-              "title": t.place.title,
-              "ccodes": t.place.ccodes,
-              "relation": t.relation[0] if t.relation else None,
-              "min": year_from_string(t.start),
-              "max": year_from_string(t.end),
-              "note": t.note,
-              "seq": sequence_value,
-          },
-          "id": i,  # Required for MapLibre conditional styling
+    feature_collection = {
+        "title": coll.title,
+        "creator": coll.creator,
+        "type": "FeatureCollection",
+        "features": [],
+        "relations": coll.rel_keywords,
+        "extent": extent,
     }
 
-    if null_geometry: # Minimise data sent to browser when using a vector tileset
-        if geometry:
-            del feature["geometry"]["coordinates"]
-            if "geowkt" in feature["geometry"]:
-                del feature["geometry"]["geowkt"]
-    elif tileset: # Minimise data to be included in a vector tileset
-        # Drop all properties except any listed here
-        properties_to_keep = ["pid", "min", "max"] # ["min", "max"] are required for layer styling and filtering
-        feature["properties"] = {k: v for k, v in feature["properties"].items() if k in properties_to_keep}
+    if null_geometry:
+        feature_collection["tilesets"] = available_tilesets
+            
+    def reduceFeature(feature, geometry):
+        if null_geometry: # Minimise data sent to browser when using a vector tileset
+            if geometry:
+                del feature["geometry"]["coordinates"]
+                if "geowkt" in feature["geometry"]:
+                    del feature["geometry"]["geowkt"]
+        elif tileset: # Minimise data to be included in a vector tileset
+            # Drop all properties except any listed here
+            properties_to_keep = ["pid", "min", "max"] # ["min", "max"] are required for layer styling and filtering
+            feature["properties"] = {k: v for k, v in feature["properties"].items() if k in properties_to_keep}
+        return feature
+        
+    if coll.collection_class == 'place':
 
-    feature_collection["features"].append(feature)
+        for index, t in enumerate(coll.traces.filter(archived=False)):
+            # Get the first annotation's sequence value
+            first_anno = t.place.annos.first()
+            sequence_value = first_anno.sequence if first_anno else None
+    
+            geoms = t.place.geoms.all()
+            geometry = t.place.geoms.all()[0].jsonb if geoms else None  # some places have no geometry
+    
+            feature = {
+                "type": "Feature",
+                "properties": {
+                    "pid": t.place.id,
+                    "cid": id_,
+                    "title": t.place.title,
+                    "ccodes": t.place.ccodes,
+                    "relation": t.relation[0] if t.relation else None,
+                    "min": year_from_string(t.start),
+                    "max": year_from_string(t.end),
+                    "note": t.note,
+                    "seq": sequence_value,
+                },
+                "geometry": geometry,
+                "id": index,  # Required for MapLibre conditional styling
+            }
+            
+            feature = reduceFeature(feature, geometry)
+    
+            feature_collection["features"].append(feature)
+        
+    else: # if coll.collection_class == 'dataset': ## Aggregate Places into Families
+    
+        # Construct families of matched places within collection
+        close_matches = CloseMatch.objects.filter(
+            Q(place_a__in=coll_places_all) & Q(place_b__in=coll_places_all)
+        )
+        G = nx.Graph()
+        for match in close_matches:
+            print(match.place_a_id, match.place_b_id)
+            G.add_edge(match.place_a_id, match.place_b_id)
+            
+        families = list(nx.connected_components(G))
+    
+        # Start places list with places which have no family connections
+        places = list(coll_places_all.exclude(id__in=G.nodes).prefetch_related('geoms').order_by('id'))
+    
+        print(f"Collection {id_}: {coll_places_all.count()} places sorted into {len(families)} families and {len(places)} unmatched.")
+    
+        if families:
+    
+            # Sort families by the first id of each sorted family - consistent ordering within the generated FeatureCollection is required between runs
+            # to maintain correlation with any associated tileset
+            for i, family in enumerate(families):
+                sorted_family = sorted(family)
+                families[i] = sorted_family
+            families = sorted(families, key=lambda x: sorted(x)[0])
+    
+            for i, family in enumerate(families):
+                print(f"Family {i + 1}: {family}")
+    
+            class FamilyPlace:
+    
+                def __init__(self, family, family_members, family_place_geoms):
+                    #Required for Place Table
+                    self.id = "-".join(str(place_id) for place_id in sorted(family))
+                    self.src_id = sorted(list(family_members.values_list('src_id', flat=True)))
+                    self.title = "|".join(set(family_members.values_list('title', flat=True)))
+                    self.ccodes = sorted(list(set(chain.from_iterable(family_members.values_list('ccodes', flat=True)))))
+                    self.minmax = [
+                        min(filter(None, family_members.values_list('minmax__0', flat=True)), default=None),
+                        max(filter(None, family_members.values_list('minmax__1', flat=True)), default=None)
+                    ]
+                    self.geoms = family_place_geoms
+                    self.seq = None
+    
+            # Loop through families
+            for family in families:
+                family_members = Place.objects.filter(id__in=family)
+                family_place_geoms = PlaceGeom.objects.filter(place_id__in=family).select_related('place')
+    
+                # Create a single pseudo-place object for each family
+                family_place = FamilyPlace(family, family_members, family_place_geoms)
+    
+                # Add the family place to `places`
+                places.append(family_place)
+    
+                print(f"Aggregated places {family_place.id}")
 
-  return JsonResponse(feature_collection, safe=False, json_dumps_params={'ensure_ascii':False,'indent':2})
+        featurecollection_min = None
+        featurecollection_max = None
+
+        for index, place in enumerate(places):
+            geometries = place.geoms.all() or None
+            geometry = None
+    
+            if geometries:
+                unioned_geometry = geometries.aggregate(union=Union('geom'))['union']
+                geometry_collection = json.loads(GeometryCollection(unioned_geometry).geojson)
+            else:
+                geometry_collection = None
+    
+            if place.minmax is not None:
+                place_min, place_max = place.minmax
+            else:
+                place_min, place_max = None, None
+            if place_min is not None:
+                if featurecollection_min is None or place_min < featurecollection_min:
+                    featurecollection_min = place_min
+            if place_max is not None:
+                if featurecollection_max is None or place_max > featurecollection_max:
+                    featurecollection_max = place_max
+    
+            is_family = isinstance(place.src_id, list)
+    
+            feature = {
+                "type": "Feature",
+                "properties": {
+                    "pid": place.id,
+                    "src_id": place.src_id if is_family else [place.src_id],
+                    "title": place.title,
+                    "ccodes": place.ccodes,
+                    "min": "null" if place.minmax is None or place_min is None else place_min, # String required by Maplibre filter test
+                    "max": "null" if place.minmax is None or place_max is None else place_max, # String required by Maplibre filter test
+                    "seq": None,
+                },
+                "geometry": geometry_collection,
+                "id": index # Required for MapLibre conditional styling
+            }
+            
+            feature = reduceFeature(feature, geometry)
+    
+            feature_collection["features"].append(feature)  
+
+        feature_collection["minmax"] = [featurecollection_min, featurecollection_max]
+
+    return JsonResponse(feature_collection, safe=False, json_dumps_params={'ensure_ascii': False})
 
 """ gl map needs this """
 # TODO:
@@ -1291,149 +1407,6 @@ class DatasetCollectionBrowseView(DetailView):
     context['datasets'] = [{"id":ds["id"], "label":ds["label"], "title":ds["title"], "extent":ds["extent"]} for ds in coll.ds_list]
 
     return context
-
-# GeoJSON for all places in a Dataset Collection INCLUDING those without geometry
-def fetch_mapdata_dscoll(id_, coll, tileset, ignore_tilesets):
-    from django.db.models import Min, Max
-    from django.db.models.functions import Coalesce
-    import networkx as nx
-    from itertools import chain
-    from places.models import Place, CloseMatch
-
-    coll_places_all = coll.places_all
-
-    available_tilesets = None
-    null_geometry = False
-    if not tileset and not ignore_tilesets:
-
-        tiler_url = os.environ.get('TILER_URL') # Must be set in /.env/.dev-whg3
-        response = requests.post(tiler_url, json={"getTilesets": {"type": "collections", "id": id_}})
-
-        if response.status_code == 200:
-            available_tilesets = response.json().get('tilesets', [])
-            null_geometry = len(available_tilesets) > 0
-
-    # Construct families of matched places within collection
-    close_matches = CloseMatch.objects.filter(
-        Q(place_a__in=coll_places_all) & Q(place_b__in=coll_places_all)
-    )
-    G = nx.Graph()
-    for match in close_matches:
-        G.add_edge(match.place_a_id, match.place_b_id)
-    families = list(nx.connected_components(G))
-
-    # Start places list with places which have no family connections
-    places = list(coll_places_all.exclude(id__in=G.nodes).prefetch_related('geoms').order_by('id'))
-
-    print(f"Collection {id_}: {coll_places_all.count()} places sorted into {len(families)} families and {len(places)} unmatched.")
-
-    if families:
-
-        # Sort families by the first id of each sorted family - consistent ordering within the generated FeatureCollection is required between runs
-        # to maintain correlation with any associated tileset
-        for i, family in enumerate(families):
-            sorted_family = sorted(family)
-            families[i] = sorted_family
-        families = sorted(families, key=lambda x: sorted(x)[0])
-
-        for i, family in enumerate(families):
-            print(f"Family {i + 1}: {family}")
-
-        class FamilyPlace:
-
-            def __init__(self, family, family_members, family_place_geoms):
-                #Required for Place Table
-                self.id = "-".join(str(place_id) for place_id in sorted(family))
-                self.src_id = sorted(list(family_members.values_list('src_id', flat=True)))
-                self.title = "|".join(set(family_members.values_list('title', flat=True)))
-                self.ccodes = sorted(list(set(chain.from_iterable(family_members.values_list('ccodes', flat=True)))))
-                self.minmax = [
-                    min(filter(None, family_members.values_list('minmax__0', flat=True)), default=None),
-                    max(filter(None, family_members.values_list('minmax__1', flat=True)), default=None)
-                ]
-                self.geoms = family_place_geoms
-                self.seq = None
-
-        # Loop through families
-        for family in families:
-            family_members = Place.objects.filter(id__in=family)
-            family_place_geoms = PlaceGeom.objects.filter(place_id__in=family).select_related('place')
-
-            # Create a single pseudo-place object for each family
-            family_place = FamilyPlace(family, family_members, family_place_geoms)
-
-            # Add the family place to `places`
-            places.append(family_place)
-
-            print(f"Aggregated places {family_place.id}")
-
-    extent = list(coll_places_all.aggregate(Extent('geoms__geom')).values())[0]
-
-    feature_collection = {
-        "title": coll.title,
-        "creator": coll.creator,
-        "relations": coll.rel_keywords,
-        "extent": extent,
-        "type": "FeatureCollection",
-        "features": [],
-    }
-
-    featurecollection_min = None
-    featurecollection_max = None
-
-    if null_geometry:
-        feature_collection["tilesets"] = available_tilesets
-
-    for index, place in enumerate(places):
-        geometries = place.geoms.all() or None
-        geometry = None
-
-        if geometries:
-            unioned_geometry = geometries.aggregate(union=Union('geom'))['union']
-            geometry_collection = json.loads(GeometryCollection(unioned_geometry).geojson)
-        else:
-            geometry_collection = None
-
-        place_min, place_max = place.minmax
-        if place_min is not None:
-            if featurecollection_min is None or place_min < featurecollection_min:
-                featurecollection_min = place_min
-        if place_max is not None:
-            if featurecollection_max is None or place_max > featurecollection_max:
-                featurecollection_max = place_max
-
-        is_family = isinstance(place.src_id, list)
-
-        feature = {
-            "type": "Feature",
-            "properties": {
-                "pid": place.id,
-                "src_id": place.src_id if is_family else [place.src_id],
-                "title": place.title,
-                "ccodes": place.ccodes,
-                "min": "null" if place.minmax is None or place_min is None else place_min, # String required by Maplibre filter test
-                "max": "null" if place.minmax is None or place_max is None else place_max, # String required by Maplibre filter test
-                "seq": None,
-            },
-            "geometry": geometry_collection,
-            "id": index # Required for MapLibre conditional styling
-        }
-
-        if null_geometry: # Minimise data sent to browser when using a vector tileset
-            if geometry:
-                del feature["geometry"]["coordinates"]
-                if "geowkt" in feature["geometry"]:
-                    del feature["geometry"]["geowkt"]
-        elif tileset: # Minimise data to be included in a vector tileset
-            # Drop all properties except any listed here
-            properties_to_keep = ["pid", "min", "max"] # ["min", "max"] are required for layer styling and filtering
-            feature["properties"] = {k: v for k, v in feature["properties"].items() if k in properties_to_keep}
-
-        feature_collection["features"].append(feature)
-
-    feature_collection["minmax"] = [featurecollection_min, featurecollection_max]
-
-    return JsonResponse(feature_collection, safe=False, json_dumps_params={'ensure_ascii': False})
 
 """ browse collection collections
     w/student section?

--- a/datasets/templates/datasets/ds_places.html
+++ b/datasets/templates/datasets/ds_places.html
@@ -387,10 +387,11 @@
 
   </div>
 
+  {{ object.vis_parameters|json_script:"vis_parameters_data" }}
   <script type="text/javascript">
     const URL_FRONT = "{{ URL_FRONT }}";
     const pageData = "{{ ds.id }}";
-    var visParameters = {{ visParameters|safe }};
+    var visParameters = JSON.parse(document.getElementById('vis_parameters_data').innerHTML);
     window.loggedin = "{{ loggedin }}";
     window.dslabel = "{{ ds.label }}";
     window.filter = "{{ filter }}";
@@ -401,6 +402,7 @@
         label: "{{ ds.label }}",
         modified: "{{ ds.last_modified_text }}",
         title: "{{ ds.title }}",
+        ds_type: "datasets"
       }];
   </script>
 

--- a/datasets/templates/datasets/ds_places.html
+++ b/datasets/templates/datasets/ds_places.html
@@ -60,8 +60,7 @@
             {% if ds.image_file %}
                 <img id="active_img"
                      class="img-responsive thumbnail float-end"
-                     src="/media/{{ ds.image_file.name }}"
-                     width="220px"/>
+                     src="/media/{{ ds.image_file.name }}"/>
             {% else %}<span><i>image here</i></span>
             {% endif %}
           </div>

--- a/datasets/templates/datasets/ds_places.html
+++ b/datasets/templates/datasets/ds_places.html
@@ -58,12 +58,10 @@
           </div>
           <div class="col-sm-3" style="position: relative;">
             {% if ds.image_file %}
-              <a href="#" class="pop">
                 <img id="active_img"
                      class="img-responsive thumbnail float-end"
                      src="/media/{{ ds.image_file.name }}"
                      width="220px"/>
-              </a>
             {% else %}<span><i>image here</i></span>
             {% endif %}
           </div>

--- a/datasets/urls.py
+++ b/datasets/urls.py
@@ -43,7 +43,7 @@ urlpatterns = [
   path('<int:id>/log', views.DatasetLogView.as_view(), name='ds_log'),
 
   # public dataset pages (tabs): metadata, browse
-  # path('<int:pk>', views.DatasetPublicView.as_view(), name='ds_meta'),
+  path('<int:pk>', views.DatasetPublicView.as_view(), name='ds_meta'),
   path('<int:id>/places', views.DatasetPlacesView.as_view(), name='ds_places'),
 
   ## DOWNLOADS

--- a/elastic/es_utils.py
+++ b/elastic/es_utils.py
@@ -281,6 +281,37 @@ def findPortalPlaces(whg_id):
     return ids
 
 """
+Fetch place ids sharing a whg_id for a given place id
+"""
+def findPortalPIDs(pid):
+    es = settings.ES_CONN
+    idx = 'whg'
+
+    try:
+        es_result = es.search(index=idx, query=esq_pid(pid))
+
+        hits = es_result.get('hits', {}).get('hits', [])
+        if hits:
+            source = hits[0].get('_source', {})
+            whg_id = source.get('whg_id')
+            relation = source.get('relation', {})
+            if not whg_id:
+                whg_id = relation.get('parent')
+
+            if whg_id:
+                shared_ids = findPortalPlaces(whg_id)
+                return shared_ids
+            else:
+                #print(f"No whg_id found for pid {pid}")
+                return []
+        else:
+            #print(f"No document found for pid {pid}")
+            return []
+    except Exception as e:
+        #print(f"Error finding shared pids for pid {pid}: {e}")
+        return []
+
+"""
 summarize a WHG hit for analysis
 """
 def profileHit(hit):

--- a/places/templates/places/place_portal.html
+++ b/places/templates/places/place_portal.html
@@ -1,8 +1,14 @@
 {% extends "main/base_webpack.html" %}
+
 {% load static %}
 {% load dataset_extras %}
 
 {% block maplibre %}
+
+{% if redirect_to %}
+    <script>window.location.href = "{{ redirect_to }}";</script>
+{% endif %}
+
   <script type="text/javascript">
     const loadMaplibre = true;
   </script>

--- a/places/templates/places/place_portal.html
+++ b/places/templates/places/place_portal.html
@@ -89,6 +89,11 @@
 							    </div>
 							</li>
 	                    </ul>
+	                    <div id="sourceOptions">
+							<p><em>Optional:</em></p>
+							<p><label for="primarySource">Primary Source:</label> <select id="primarySource" name="primarySource" {% if payload|length > 1 %}data-bs-toggle="tooltip" data-bs-title="Change this if you wish to link to a different source, which might have a different place name."{% else %}disabled{% endif %}></select></p>
+							<p><input type="checkbox" id="includeAll" name="includeAll" checked data-bs-toggle="tooltip" data-bs-title="If selected, this place in your Collection will be linked to all of the sources associated with it, including any which might become associated with it in future. <b>Leave this selected unless you want to use only the specific <i>Primary Source</i> selected above.<b>"> <label for="includeAll">include all sources</label></p>				
+						</div>
                 	</span>
                     <div id="submission_alerts"></div>
                 </div>

--- a/places/templates/places/place_portal.html
+++ b/places/templates/places/place_portal.html
@@ -29,10 +29,12 @@
 			<h5>{{ portal_headword }}</h5>
 			<div id="gloss"><!-- Populated dynamically from context in JavaScript --></div>
 			
-			<p class="my-0"><span id="addtocoll" class="me-1">
-				<span id="added_flash" class="mr-2 hidden" style="background-color: yellow; position:absolute; top:10px; right:10px;"> added! </span>
-				<a id="addchecked" href="#">add to collection <i class="fas fa-plus-circle"></i> </a>
-	        </span></p>
+			{% if user.is_authenticated %}
+				<p class="my-0"><span id="addtocoll" class="me-1">
+					<span id="added_flash" class="mr-2 hidden" style="background-color: yellow; position:absolute; top:10px; right:10px;"> added! </span>
+					<button id="addchecked" class="btn btn-warning btn-sm" data-bs-toggle="modal" data-bs-target="#addtocoll_popup"><i class="fas fa-plus-circle"></i> Add to a Collection</button>
+		        </span></p>
+			{% endif %}
 	        
 	        <div id="sources" class="mt-2 bg-light info-box">
 	          <h6 class="mt-1 ms-1 strong-red">Sources</h6>
@@ -54,30 +56,46 @@
     </div>
 </div>
 
-<div id="addtocoll_popup" class="p-2 small hidden">
-	<ul id="my_collections" class="no-bullets">
-	    {% for c in my_collections %}
-	        <li>
-	            <label>
-	                <input type="radio" name="collection_radio" value="{{ c.id }}" class="collection_radio">
-	                {{ c.title }}
-	            </label>
-	        </li>
-	    {% endfor %}
-	</ul>
-  	<hr/>
-    <p class="mb-0 ital">
-        <label>
-            <input type="radio" name="collection_radio" class="collection_radio" value="new">
-            Create New
-        </label>
-    </p>
-  	<p id="title_form" class="small hidden">
-    	<input id="title_input" type="text" placeholder="Collection title" width="20"/>
-    	<button id="b_create_coll" type="button">create</button>
-  	</p>
+<div id="addtocoll_popup" class="modal fade">
+    <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
+        <div class="modal-content">
+            <form id="collection_form" class="needs-validation" novalidate>
+                <div class="modal-header">
+                    <h5>Add <b>{{ portal_headword }}</b> to a Collection</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                	<span class="form-inputs">
+	                    <p><em>Select from one of your Place Collections listed below, or create a new Collection:</em></p>
+	                    <ul id="my_collections" class="no-bullets">
+	                        {% for c in my_collections %}
+	                            <li>
+	                            	<input id="radio_{{ c.id }}" type="radio" class="form-check-input" name="collection" value="{{ c.id }}" required>
+	                                <label class="form-check-label" for="radio_{{ c.id }}">{{ c.title }}</label>
+	                            </li>
+	                        {% endfor %}
+							<li>
+							    <div class="form-check form-check-inline">
+							        <input id="radio_new" type="radio" class="form-check-input" name="collection" value="-1" required>
+							        <label class="form-check-label" for="radio_new"><em>Create New:</em></label>
+								    <input id="title_input" type="text" class="form-control" name="title" placeholder="Collection title" width="20" required disabled>
+								    <div class="invalid-feedback">Please enter a new Collection title, or select an existing Collection.</div>
+							    </div>
+							</li>
+	                    </ul>
+                	</span>
+                    <div id="submission_alerts"></div>
+                </div>
+                <div class="modal-footer form-inputs">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-primary">Go Ahead</button>
+                </div>
+            </form>
+        </div>
+    </div>
 </div>
 
+{% csrf_token %} <!-- Used for Django POST requests -->
 <script type="text/javascript">
     let allts = {{ allts }};
     const extent = {{ extent }};

--- a/places/urls.py
+++ b/places/urls.py
@@ -14,7 +14,8 @@ urlpatterns = [
 
     # START new urls-> views (kg 2023-10-31)
     path('portal/', views.PlacePortalView.as_view(), name='place-portal'),
-    path('portal/<str:encoded_ids>/', views.PlacePortalView.as_view(), name='place-portal-permalink'),
+    path('portal/<int:pid>/', views.PlacePortalView.as_view(), name='place-portal-pid'),
+    path('portal/<str:encoded_ids>/', views.PlacePortalView.as_view(), name='place-portal-multipid'),
     path('<int:whg_id>/portal/', views.PlacePortalView.as_view(), name='place-portal-whg-id'),
 
     # added for sessions approach

--- a/traces/models.py
+++ b/traces/models.py
@@ -43,6 +43,9 @@ class TraceAnnotation(models.Model):
     motivation = models.CharField(max_length=20, default='locating') # choices? locating, describing
     owner = models.ForeignKey(User, related_name='annotations', on_delete=models.CASCADE)
     created = models.DateTimeField(auto_now_add=True, null=False, blank=True)
+    
+    # Flag to indicate whether the Place is to be treated as a surrogate for its CloseMatch family of Places  
+    include_matches = models.BooleanField(default=True)
 
     # flagged True when edit is made to initial 'blank'
     saved = models.BooleanField(default=False)

--- a/whg/webpack/css/mapAndTable.css
+++ b/whg/webpack/css/mapAndTable.css
@@ -199,6 +199,24 @@
 	max-height: 100%;
 }
 
+/* Styling for getPlace() Detail */
+#detail {
+    display: flex!important;	
+}
+#detail > img {
+    flex: 0 0 auto;
+    margin-right: 10px;
+    height: auto;
+    width: auto;
+    max-height: 8rem;
+    max-width: 30%;
+    order: 2;
+}
+#detail > div {
+    flex: 1 1 auto;
+    order: 1;
+}
+
 /* Styling for the attribution text */
 .attribution-text {
   margin: 10px 0;

--- a/whg/webpack/css/portal.css
+++ b/whg/webpack/css/portal.css
@@ -184,3 +184,11 @@ li:not(.showing) span.showing {
 .maplibregl-ctrl-top-right .maplibregl-ctrl {
 	margin-top: 0;
 }
+
+.modal-content {
+	height: auto; /* Required to override setting in /static/css/styles.css */
+}
+
+.modal-content input[type="radio"] {
+    vertical-align: text-bottom;
+}

--- a/whg/webpack/css/portal.css
+++ b/whg/webpack/css/portal.css
@@ -75,10 +75,43 @@ div.overlay .left .item {
 .source-box {
     background-color: white;
     border: 1px gainsboro solid;
-    margin: 0.1rem;
-    padding: 0.1rem;
+    border-radius: .3rem;
+    margin: .1rem;
+    padding: .4rem;
 }
 
+.source-box:not([disabled]) {
+    cursor: pointer;
+}
+
+.source-box.primary-place {
+    border-color: #b13333;
+}
+
+#sourceOptions {
+    background-color: #ffc10736;
+    border: 1px gainsboro solid;
+    border-radius: 0.3rem;
+    margin-top: 1rem;
+    padding: 0.4rem;
+    font-size: smaller;
+    position: relative;
+}
+
+#sourceOptions > p:first-of-type {
+    position: absolute;
+    top: -0.7rem;
+    left: 0.5rem;
+    text-shadow: 0 0 0.3rem white;
+}
+
+#sourceOptions #primarySource {
+    vertical-align: middle;
+}
+
+#sourceOptions #includeAll {
+    vertical-align: text-bottom;
+}
 
 /*#mapOverlays .column .left .item {*/
 .overlay.left.item {

--- a/whg/webpack/js/base.js
+++ b/whg/webpack/js/base.js
@@ -196,7 +196,7 @@ Promise.all([
 	])
 	.then(function() {
 		
-		$("[data-bs-toggle='tooltip']").tooltip(); // Initialize Bootstrap tooltips
+		$("[data-bs-toggle='tooltip']").tooltip({html: true}); // Initialize Bootstrap tooltips
 		
 		document.querySelector('body').style.opacity = 1;
 		

--- a/whg/webpack/js/collections.js
+++ b/whg/webpack/js/collections.js
@@ -15,6 +15,7 @@ function getCookie(name) {
     }
     return cookieValue;
 }
+
 // export function add_to_collection(coll, pids, checked_rows) {
 export function add_to_collection(coll, checked_rows) {
 	console.log('add_to_collection()', coll, checked_rows)
@@ -61,107 +62,47 @@ export function add_to_collection(coll, checked_rows) {
 	/*resetSearch()*/
 }
 
-export function init_collection_listeners(checked_rows) {
+function create_collection() {
+	let title = $("#title_input").val()
+	if (title != '') {
+		// create new place collection, return id
+		var formData = new FormData()
+		formData.append('title', title)
+		formData.append('csrfmiddlewaretoken', '{{ csrf_token }}');
+		$.ajax({
+			type: 'POST',
+			enctype: 'multipart/form-data',
+			url: '/collections/flash_create/',
+			processData: false,
+			contentType: false,
+			cache: false,
+			data: formData,
+			success: function(data) {
+				el = $('<li><a class="a_addtocoll" href="#" ref=' + data.id + '>' + data.title + '</a></li>')
+				el.click(function() {
+					coll = data.id
+					// pids = checked_rows
+					// add_to_collection(coll, pids, checked_rows)
+					add_to_collection(coll, checked_rows)
+					console.log('checked_rows to coll', checked_rows, coll)
+				})
+				$("#my_collections").append(el)
+			}
+		})
+		$("#title_form").hide()
+	} else {
+		alert('Your new collection needs a title!')
+	}
+}
 
+export function init_collection_listeners(checked_rows) {
+	
+	// Used in `mapAndTable.js`
 	$(".a_addtocoll").click(function() {
 		let coll = $(this).attr('ref')
 		// let pids = checked_rows
 		// add_to_collection(coll, pids, checked_rows)
 		add_to_collection(coll, checked_rows)
-
 	})
 	
-	$("#b_create_coll").click(function() {
-		let title = $("#title_input").val()
-		if (title != '') {
-			// create new place collection, return id
-			var formData = new FormData()
-			formData.append('title', title)
-			formData.append('csrfmiddlewaretoken', '{{ csrf_token }}');
-			$.ajax({
-				type: 'POST',
-				enctype: 'multipart/form-data',
-				url: '/collections/flash_create/',
-				processData: false,
-				contentType: false,
-				cache: false,
-				data: formData,
-				success: function(data) {
-					el = $('<li><a class="a_addtocoll" href="#" ref=' + data.id + '>' + data.title + '</a></li>')
-					el.click(function() {
-						coll = data.id
-						// pids = checked_rows
-						// add_to_collection(coll, pids, checked_rows)
-						add_to_collection(coll, checked_rows)
-						console.log('checked_rows to coll', checked_rows, coll)
-					})
-					$("#my_collections").append(el)
-				}
-			})
-			$("#title_form").hide()
-		} else {
-			alert('Your new collection needs a title!')
-		}
-	})
-
-	$("#create_coll_link").click(function() {
-		console.log('open title input')
-		$("#title_form").show()
-	})
-
-	$(".closer").click(function(){
-      $(this).parent().hide()
-	})
-
-	// $("#addchecked").click(function(){
-    //   $("#addtocoll_popup").fadeIn()
-	// })
-
-	// single pid for place portal; adapt for multi-select elsewhere
-	// $(".action:radio").click(function(event){
-	// 		event.stopPropagation()
-	// 		console.log('radio clicked')
-	// 		let pid = $('input[name="r_anno"]:checked').data('id');
-	// 		console.log('checked radio for pid:', pid)
-	// 		$("#addtocoll").fadeIn()
-	// 		window.checked_cards = []
-	// 		// checked_cards.push($(this).data("id"))
-	// 		window.checked_cards.push(pid)
-	// 		console.log('checked_cards', window.checked_cards)
-	// })
-
-	// Used in ds_places.html publication page
-	// Listen for table row click (assigned using event delegation to allow for redrawing)
-	$("body").on("click", "#placetable tbody tr", function() {
-		const thisy = $(this)
-		// get id
-		const pid = $(this)[0].cells[0].textContent
-		// is checkbox checked?
-		// if not, ensure row pid is not in checked_rows
-		if (window.loggedin == true) {
-			chkbox = thisy[0].cells[3].firstChild
-			if (chkbox.checked) {
-				console.log('chkbox.checked')
-				checked_rows.push(pid)
-				$("#selection_status").fadeIn()
-				/*$("#addtocoll").fadeIn()*/
-				console.log('checked_rows', checked_rows)
-				$("#sel_count").html(' ' + checked_rows.length + ' ')
-			} else {
-				const index = checked_rows.indexOf(pid);
-				if (index > -1) {
-					checked_rows.splice(index, 1)
-					if (checked_rows.length == 0) {
-						$("#addtocoll").fadeOut()
-						$("#addtocoll_popup").hide()
-					}
-				}
-				console.log(pid + ' removed from checked_rows[]', checked_rows)
-			}
-		}
-	
-	});
-
-
-
 }

--- a/whg/webpack/js/enlarge.js
+++ b/whg/webpack/js/enlarge.js
@@ -2,11 +2,11 @@
 
 $.fn.enlarge = function() {
     this.on('click', function() {
-        const imgClone = $(this).clone().removeClass().css({cursor: 'pointer'});
+        const imgClone = $(this).clone().removeClass().css({'max-width': '80vw', 'max-height': '80vh', cursor: 'pointer'});
         const closeButton = $('<button type="button" class="btn-close" aria-label="Close"></button>').css({position: 'absolute', 'background-color': 'white', right: '1.2em', top: '1.2em', 'z-index': '999'});
         const modalBody = $('<div class="modal-body"></div>').append(imgClone);
         const modalContent = $('<div class="modal-content"></div>').css({width: 'fit-content', height: 'fit-content'}).append(closeButton, modalBody);
-        const modalDialog = $('<div class="modal-dialog"></div>').append(modalContent);
+        const modalDialog = $('<div class="modal-dialog"></div>').css({'max-width': '100vw', 'max-height': '100vh'}).append(modalContent);
         const modal = $('<div class="modal fade"></div>').append(modalDialog);
         
         closeButton.on('click', function() {

--- a/whg/webpack/js/enlarge.js
+++ b/whg/webpack/js/enlarge.js
@@ -1,0 +1,24 @@
+// Create a Bootstrap dialog containing a clicked image
+
+$.fn.enlarge = function() {
+    this.on('click', function() {
+        const imgClone = $(this).clone().removeClass().css({cursor: 'pointer'});
+        const closeButton = $('<button type="button" class="btn-close" aria-label="Close"></button>').css({position: 'absolute', 'background-color': 'white', right: '1.2em', top: '1.2em', 'z-index': '999'});
+        const modalBody = $('<div class="modal-body"></div>').append(imgClone);
+        const modalContent = $('<div class="modal-content"></div>').css({width: 'fit-content', height: 'fit-content'}).append(closeButton, modalBody);
+        const modalDialog = $('<div class="modal-dialog"></div>').append(modalContent);
+        const modal = $('<div class="modal fade"></div>').append(modalDialog);
+        
+        closeButton.on('click', function() {
+            modal.modal('hide');
+        });
+
+        modal.on('hidden.bs.modal', function() {
+            modal.remove();
+        });
+
+        imgClone.on('load', function() {
+        	modal.modal('show');
+        });
+    });
+};

--- a/whg/webpack/js/getPlace.js
+++ b/whg/webpack/js/getPlace.js
@@ -38,7 +38,7 @@ function parsePlace(data) {
 	window.featdata = data
 	var descrip = '';
 
-	if (!!data.datasets && data.datasets.length > 0) {
+	if (!!window.ds_list[0]['ds_type'] && !!window.ds_list[0]['ds_type'] == 'collections' && !!data.datasets && data.datasets.length > 0) {
 		const dataset_links = data.datasets.map(ds => `<a href="/datasets/${ds.id}/places" target="_blank" data-bs-toggle="tooltip" data-bs-title="View <i>${ds.title}</i> in a new tab.">${ds.title} <i class="fas fa-external-link-alt linky"></i></a>`).join('; ')
 		descrip += `<p class="mb-0"><b>Dataset${data.datasets.length == 1 ? '' : 's'}</b>: ${dataset_links}.</p>`;
 	}

--- a/whg/webpack/js/getPlace.js
+++ b/whg/webpack/js/getPlace.js
@@ -14,31 +14,27 @@ export function getPlaceBouncing(pid, cid, spinner_detail, callback) {
     const cidQueryParam = Number.isInteger(cid) ? `?cid=${cid}` : '';
     $.ajax({
         url: `/api/place/${pid}${cidQueryParam}`,
-    }).done(handlePlaceData);		
-
-	function handlePlaceData(data) {
-	    if (cidQueryParam=='') {
-	        $("#detail").html(parsePlace(data));
-	    } else {
-	        window.payload = data;
-	        $("#anno_title").html('<span class="larger text-danger"><b>' + data.title + '</b></span>');
-	        $("#anno_body").html(parseAnno(data));
-	        $("#anno_img").html(data.traces.image_file);
-	    }
-	    $('.toggle-truncate').toggleTruncate();
-	    if (spinner_detail) spinner_detail.stop();
-	
-	    if (typeof callback === 'function') {
-	        callback(data);
-	    }
-	}
+    }).done(data => {
+        if (cidQueryParam === '') {
+            parsePlace(data);
+        } else {
+            window.payload = data;
+            parseAnno(data);
+        }
+        $('#detail .toggle-truncate').toggleTruncate();
+        $('#detail img').enlarge();
+        if (spinner_detail) spinner_detail.stop();
+        if (typeof callback === 'function') {
+            callback(data);
+        }
+    });
 }
 
 function parsePlace(data) {
 	window.featdata = data
 	var descrip = '';
 
-	if (!!window.ds_list[0]['ds_type'] && !!window.ds_list[0]['ds_type'] == 'collections' && !!data.datasets && data.datasets.length > 0) {
+	if (!!window.ds_list[0]['ds_type'] && window.ds_list[0]['ds_type'] == 'collections'/* && !!data.datasets && data.datasets.length > 0*/) {
 		const dataset_links = data.datasets.map(ds => `<a href="/datasets/${ds.id}/places" target="_blank" data-bs-toggle="tooltip" data-bs-title="View <i>${ds.title}</i> in a new tab.">${ds.title} <i class="fas fa-external-link-alt linky"></i></a>`).join('; ')
 		descrip += `<p class="mb-0"><b>Dataset${data.datasets.length == 1 ? '' : 's'}</b>: ${dataset_links}.</p>`;
 	}
@@ -118,45 +114,40 @@ function parsePlace(data) {
 	if (!!data.minmax && data.minmax.length == 2 && (data.minmax[0] || data.minmax[1]) ) {
 		descrip += `<p><b>When</b>: earliest: ${data.minmax[0] ? data.minmax[0] : '?'}; latest: ${data.minmax[1] ? data.minmax[1] : '?'}</p>`;
 	}
-
-	return `<div><p><b>Title</b>: <span id="row_title" class="larger text-danger">${data.title}</span></p>${descrip}</div>`;
+	
+	$("#detail").html(`<div><p><b>Title</b>: <a href="/places/portal/${data.id}" target="_blank" data-bs-toggle="tooltip" title="View all WHG records for this place."><span id="row_title" class="larger text-danger">${data.title} <i class="fas fa-external-link-alt linky"></i></span></a></p>${descrip}</div>`);
 }
 
 // Traces (annotations)
 function parseAnno(data) {
-	let descrip = ''
+    
+	var $descrip = $("<div></div>");
+	$("#detail").empty().append($descrip);
 	
 	if (!!data.traces && data.traces.length > 0) {
 		data.traces.forEach(trace => {
 			const t = trace.fields;
+			$descrip.append(`<p><b>Title</b>: <a href="/places/portal/${t.place}" target="_blank" data-bs-toggle="tooltip" title="View all WHG records for this place."><span id="row_title" class="larger text-danger">${data.title} <i class="fas fa-external-link-alt linky"></i></span></a></p>`);
 			if (t.relation == '[""]' && t.note == null && t.start == null) {
-				descrip += '<i>none yet</i>';
+				$descrip.append('<i>none yet</i>');
 			} else {
 				if (t.relation) {
-					descrip += `<p class="mb-0"><b>Relation</b>: ${JSON.parse(t.relation)[0]}</p>`;
+					$descrip.append(`<p class="mb-0"><b>Relation</b>: ${JSON.parse(t.relation)[0]}</p>`);
 				}
 				if (t.note) {
-					descrip += `<p class="mb-0"><b>Notes</b>: <span class="toggle-truncate">${t.note}</span></p>`;
+					$descrip.append(`<p class="mb-0"><b>Notes</b>: <span class="toggle-truncate">${t.note}</span></p>`);
 				}
 				if (t.start) {
-					descrip += `<p class="mb-0"><b>Begin/End</b>: ${(t.start ?? "")}/${(t.end ?? '')}</p>`;
+					$descrip.append(`<p class="mb-0"><b>Begin/End</b>: ${(t.start ?? "")}/${(t.end ?? '')}</p>`);
 				}
 			}
 			let imgpath = t.image_file
-			if (imgpath != "") {
-				// display annotation image if any
-				$("#anno_img").attr('src', '/media/' + imgpath)
-			} else {
-				// trace has no image
-				$("#active_img").attr('src', `/media/${ window.collimagepath }`)
+			if (imgpath != "") { // display annotation image if any
+				$("#detail").prepend(`<img src="/media/${imgpath}" class="thumbnail">`);
 			}
 		});
 	}
 	else {
-		console.log('no trace for selected place')
-		// restore collection image if others have been viewed
-		$("#active_img").attr('src', `/media/${ window.collimagepath }`)		
+		console.log('no trace for selected place');		
 	}
-
-	return descrip
 }

--- a/whg/webpack/js/getPlace.js
+++ b/whg/webpack/js/getPlace.js
@@ -127,7 +127,12 @@ function parseAnno(data) {
 	if (!!data.traces && data.traces.length > 0) {
 		data.traces.forEach(trace => {
 			const t = trace.fields;
-			$descrip.append(`<p><b>Title</b>: <a href="/places/portal/${t.place}" target="_blank" data-bs-toggle="tooltip" title="View all WHG records for this place."><span id="row_title" class="larger text-danger">${data.title} <i class="fas fa-external-link-alt linky"></i></span></a></p>`);
+			$descrip.append(`
+				<p><b>Title</b>: 
+					<a href="${t.include_matches ? `/places/portal/${t.place}` : `/places/${t.place}/detail`}" target="_blank" data-bs-toggle="tooltip" title="View ${t.include_matches ? "all WHG records" : "details"} for this place.">
+						<span id="row_title" class="larger text-danger">${data.title} <i class="fas fa-external-link-alt linky"></i></span>
+					</a>
+				</p>`);
 			if (t.relation == '[""]' && t.note == null && t.start == null) {
 				$descrip.append('<i>none yet</i>');
 			} else {

--- a/whg/webpack/js/mapAndTable.js
+++ b/whg/webpack/js/mapAndTable.js
@@ -10,7 +10,6 @@ import { initUtils, initInfoOverlay, startSpinner, minmaxer, get_ds_list_stats, 
 import { initialiseTable } from './tableFunctions';
 import { init_collection_listeners } from './collections';
 import SequenceArcs from './mapSequenceArcs';
-import { add_to_collection } from './collections.js';
 
 let ds_listJSON = document.getElementById('ds_list_data') || false;
 if (ds_listJSON) {

--- a/whg/webpack/js/mapAndTable.js
+++ b/whg/webpack/js/mapAndTable.js
@@ -9,7 +9,8 @@ import { toggleFilters } from './mapFilters';
 import { initUtils, initInfoOverlay, startSpinner, minmaxer, get_ds_list_stats, deepCopy } from './utilities';
 import { initialiseTable } from './tableFunctions';
 import { init_collection_listeners } from './collections';
-import SequenceArcs from './mapSequenceArcs';
+import SequenceArcs from './mapSequenceArcs';import './toggle-truncate.js';
+import './enlarge.js';
 
 let ds_listJSON = document.getElementById('ds_list_data') || false;
 if (ds_listJSON) {
@@ -101,6 +102,8 @@ Promise.all([mapLoadPromise, ...dataLoadPromises, Promise.all(datatables_CDN_fal
 .then(function () {
 	
 	initOverlays(mappy.getContainer());
+	
+    $('.thumbnail').enlarge();
 	
 	let allFeatures = [];
 	let allExtents = [];


### PR DESCRIPTION
Mostly work on Add place __set__ to place collection
[#173](https://github.com/WorldHistoricalGazetteer/whg3/issues/173)

Difficult to test without a fuller test dataset, and `places/views.py` in particular will need some further refactoring before June 1st.

Without the alteration made to `attest_collections` in `places/views.py`, newly-made Collections would not show up in the list at the bottom of the Portal Page, which would be confusing for users.

AggPlaces works solely by setting a `include_matches` flag on the TraceAnnotation (_remember migrations_). When the Collection is browsed, this flag causes the geometry of the Place to be substituted with that of its most-linked CloseMatch sibling, and the Title link in the Detail box is switched from the place detail page to the place portal page.