### PR TITLE
Remove European Russia and Asiatic Russia regions

### DIFF
--- a/media/data/regions_countries.json
+++ b/media/data/regions_countries.json
@@ -14,17 +14,6 @@
                 ]
             },
             {
-                "id": 73,
-                "text": "Asiatic Russia",
-                "ccodes": [
-                    "CN",
-                    "KP",
-                    "KZ",
-                    "MN",
-                    "RU"
-                ]
-            },
-            {
                 "id": 74,
                 "text": "Australia/New Zealand",
                 "ccodes": [
@@ -165,24 +154,6 @@
                     "RU",
                     "SI",
                     "TR",
-                    "UA"
-                ]
-            },
-            {
-                "id": 81,
-                "text": "European Russia",
-                "ccodes": [
-                    "AZ",
-                    "BY",
-                    "EE",
-                    "GE",
-                    "FI",
-                    "KZ",
-                    "LT",
-                    "LV",
-                    "NO",
-                    "PL",
-                    "RU",
                     "UA"
                 ]
             },


### PR DESCRIPTION
I have no idea why these regions exist, and why "European Russia" include almost all Europe, even countries that were never part of Soviet Union. Same with "Asiatic Russia" - why China is part of Asiatic Russia? 
As I see, these are the only regions that have name of country in its name.
Also, these 2 are the only ones that are not in the current UN geoscheme https://en.wikipedia.org/wiki/United_Nations_geoscheme

The pull request is to the "staging" branch, which is the default branch in the repo.