### PR TITLE
fix(infra): disable redis RDB/AOF persistence (cache + broker only)

### DIFF
--- a/compose/docker-compose-template.j2
+++ b/compose/docker-compose-template.j2
@@ -97,6 +97,10 @@ services:
       - {{ ENV_CONTEXT }}
     platform: linux/amd64
     image: redis:bullseye
+    # Redis here is only a cache + Celery broker (disposable). Disable RDB/AOF
+    # persistence so a corrupt dump.rdb can never wedge startup (see 2026-06-03
+    # outage). Empty --save string turns snapshotting off.
+    command: ["redis-server", "--save", "", "--appendonly", "no"]
     container_name: redis_{{ ENV_CONTEXT }}_{{ BRANCH }}
     {% if MEM_LIMIT_REDIS is defined %}
     mem_limit: {{ MEM_LIMIT_REDIS }}


### PR DESCRIPTION
## Why

Production outage **2026-06-03**: every page 500'd with `ConnectionInterrupted: Error -3 connecting to redis:6379. Temporary failure in name resolution`. Root cause: `redis_whgazetteer-org_main` crash-looped on a corrupt `dump.rdb` (`RDB CRC error. Aborting now.`); while redis was down, Docker DNS couldn't resolve the `redis` service, so the web container failed on every `caches[...].get()`.

## Change

This redis holds only **cache + Celery broker** data (disposable), so it should never persist to disk. Add a `command` to the redis service turning off RDB (`--save ""`) and AOF (`--appendonly no`) — a missing/corrupt dump can then never wedge startup. Edited in the source template `compose/docker-compose-template.j2` (rendered by `server-admin/load_env.py`).

## Already done on the prod host (live)
- Removed the corrupt `dump.rdb`; redis restarted healthy (empty).
- `vm.overcommit_memory=1` live + persisted (`/etc/sysctl.d/99-redis-overcommit.conf`).
- `redis-cli config set save "" / appendonly no` on the running container.

This PR makes persistence-off **durable across container recreation** (CONFIG SET is runtime-only).
