### PR TITLE
feat(credit): CRediT contributions foundation (Phase 2a)

### DIFF
--- a/developer/plan-citations-phase2-credit.prompt.md
+++ b/developer/plan-citations-phase2-credit.prompt.md
@@ -1,0 +1,39 @@
+# Phase 2 — CRediT contributions
+
+**Parent design:** `developer/plan-citations-licences-credit.prompt.md` (§3.3 Contribution model, §4.1 CSL, §4.2 DataCite, §4.6 submission UI). Implements issue [place#99](https://github.com/WorldHistoricalGazetteer/place/issues/99).
+**Goal:** model attribution as first-class, role-tagged contributions (CRediT) that can attach to datasets, collections, *and* gazetteer-registry entries, replacing the free-text `creator`/`contributors` split as the source of truth.
+
+`persons.Person` already carries `orcid` + `affiliation` (first-class), so no Person change is needed — Phase 2 builds on it.
+
+## Split (foundation first; the wiring touches production rendering/DOI)
+
+### Phase 2a — foundation (this PR; additive, low-risk)
+A new `persons.CreditRole` vocabulary + `persons.Contribution` through-model, admin, tests. **No change to existing CSL/DOI/templates**, so nothing in the live render/DOI path moves yet.
+
+- **`CreditRole`** — `TextChoices` of the 14 NISO CRediT roles, values = canonical CRediT slugs (so `https://credit.niso.org/contributor-roles/<slug>/` is derivable):
+  `conceptualization, data-curation, formal-analysis, funding-acquisition, investigation, methodology, project-administration, resources, software, supervision, validation, visualization, writing-original-draft, writing-review-editing`.
+- **`Contribution`** — generic-relation through-model:
+  - `person` FK → `persons.Person` (PROTECT, related_name `contributions`)
+  - `role` (CreditRole), `degree` (lead/equal/supporting, blank), `is_corresponding` (bool), `order` (PositiveSmallInteger)
+  - generic FK: `content_type` + `object_id` + `GenericForeignKey('target')` → targets `Dataset` | `Collection` | `GazetteerRegistryEntry`
+  - `UniqueConstraint(person, role, content_type, object_id)`; index on `(content_type, object_id)`; `Meta.ordering = ['order']`
+  - `credit_uri` property → `https://credit.niso.org/contributor-roles/{role}/`
+- **Admin:** register `Contribution` (autocomplete `person`); a generic `Contribution` inline could be added to Dataset/Collection admin later.
+- **Tests:** role-slug sanity, generic relation to a `Dataset`, uniqueness constraint, `credit_uri`.
+
+Migration: `persons/0003_contribution` (depends on `persons/0002`, `contenttypes/0002`).
+
+### Phase 2b — wiring (separate PR; changes live code paths, deploy carefully)
+1. **CSL** (`utils/csl_citation_formatter.py`): read `Contribution` rows (and authority `contributors_csl`) → emit CSL `author` (creator-equivalent roles) + `contributor` arrays; **fix the `person.first/.middle/.last` bug** (use `Person.given/family/literal`); fall back to `parse_names()` only when no structured contributions exist.
+2. **DataCite** (`utils/doi.py`): add a `contributors` array (currently only `creators`), `contributorType` from CRediT via the JATS4R mapping, `nameIdentifiers` (ORCID) + `affiliation`.
+3. **Importer:** management command `import_freetext_contributors` — reuse `parse_names()` to seed `Person` + `Contribution` from existing `creator`/`contributors` strings (idempotent; default role mapping creator→Conceptualization, contributors→Data curation; editable after).
+4. **Submission/edit UI** (§4.6): repeatable contributor rows (person + ORCID + affiliation × roles × degree × corresponding) on dataset upload/validate + collection forms, backed by `Contribution`.
+
+## CRediT → DataCite contributorType mapping (for 2b)
+Per JATS4R: most CRediT roles map to DataCite `contributorType` values (e.g. Data curation→DataCurator, Software→Software, Supervision→Supervisor, Project administration→ProjectManager, Funding acquisition→…); roles without a clean DataCite equivalent fall back to `Other` with the CRediT role recorded in `nameIdentifiers`/a note. Finalise the table in 2b against the JATS4R reference.
+
+## Validation
+`python3 manage.py test persons` in a one-off container against the dev Postgres (throwaway test_ DB), per [[reference_deploy_script]] harness. No prod migration until reviewed; Phase 2a migration is additive (new table only).
+
+## Leapfrog
+Branch `credit` off `main`. Phase 2a touches only `persons` (models/admin/migration) — additive, no collision risk. Same merge→deploy path as Phase 1 (`deploy prod pull → migrate → restart`).

--- a/persons/admin.py
+++ b/persons/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from .models import Person, EmailAddress
+from .models import Person, EmailAddress, Contribution
 
 class EmailAddressInline(admin.TabularInline):
     model = Person.emails.through
@@ -32,3 +32,13 @@ class EmailAddressAdmin(admin.ModelAdmin):
     list_display = ('address',)
 
 admin.site.register(EmailAddress, EmailAddressAdmin)
+
+
+@admin.register(Contribution)
+class ContributionAdmin(admin.ModelAdmin):
+    list_display = ('person', 'role', 'degree', 'is_corresponding',
+                    'content_type', 'object_id', 'order')
+    list_filter = ('role', 'degree', 'is_corresponding', 'content_type')
+    search_fields = ('person__family', 'person__given', 'person__orcid', 'object_id')
+    autocomplete_fields = ('person',)
+    ordering = ('content_type', 'object_id', 'order')

--- a/persons/migrations/0003_contribution.py
+++ b/persons/migrations/0003_contribution.py
@@ -1,0 +1,37 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contenttypes', '0002_remove_content_type_name'),
+        ('persons', '0002_emailaddress_remove_person_email_and_more'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Contribution',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('role', models.CharField(choices=[('conceptualization', 'Conceptualization'), ('data-curation', 'Data curation'), ('formal-analysis', 'Formal analysis'), ('funding-acquisition', 'Funding acquisition'), ('investigation', 'Investigation'), ('methodology', 'Methodology'), ('project-administration', 'Project administration'), ('resources', 'Resources'), ('software', 'Software'), ('supervision', 'Supervision'), ('validation', 'Validation'), ('visualization', 'Visualization'), ('writing-original-draft', 'Writing – original draft'), ('writing-review-editing', 'Writing – review & editing')], max_length=32)),
+                ('degree', models.CharField(blank=True, choices=[('lead', 'Lead'), ('equal', 'Equal'), ('supporting', 'Supporting')], max_length=10)),
+                ('is_corresponding', models.BooleanField(default=False)),
+                ('order', models.PositiveSmallIntegerField(default=0)),
+                ('object_id', models.CharField(max_length=64)),
+                ('content_type', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='contenttypes.contenttype')),
+                ('person', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, related_name='contributions', to='persons.person')),
+            ],
+            options={
+                'ordering': ['order'],
+            },
+        ),
+        migrations.AddIndex(
+            model_name='contribution',
+            index=models.Index(fields=['content_type', 'object_id'], name='contribution_target_idx'),
+        ),
+        migrations.AddConstraint(
+            model_name='contribution',
+            constraint=models.UniqueConstraint(fields=('person', 'role', 'content_type', 'object_id'), name='unique_contribution'),
+        ),
+    ]

--- a/persons/models.py
+++ b/persons/models.py
@@ -1,3 +1,5 @@
+from django.contrib.contenttypes.fields import GenericForeignKey
+from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.core.validators import RegexValidator, EmailValidator
 from django.utils.translation import gettext_lazy as _
@@ -62,3 +64,79 @@ class EmailAddress(models.Model):
     class Meta:
         verbose_name = "Email Address"
         verbose_name_plural = "Email Addresses"
+
+
+class CreditRole(models.TextChoices):
+    """The 14 NISO CRediT contributor roles (https://credit.niso.org).
+
+    Values are the canonical CRediT slugs, so the term URI is derivable as
+    ``https://credit.niso.org/contributor-roles/<value>/``.
+    """
+    CONCEPTUALIZATION = "conceptualization", _("Conceptualization")
+    DATA_CURATION = "data-curation", _("Data curation")
+    FORMAL_ANALYSIS = "formal-analysis", _("Formal analysis")
+    FUNDING_ACQUISITION = "funding-acquisition", _("Funding acquisition")
+    INVESTIGATION = "investigation", _("Investigation")
+    METHODOLOGY = "methodology", _("Methodology")
+    PROJECT_ADMINISTRATION = "project-administration", _("Project administration")
+    RESOURCES = "resources", _("Resources")
+    SOFTWARE = "software", _("Software")
+    SUPERVISION = "supervision", _("Supervision")
+    VALIDATION = "validation", _("Validation")
+    VISUALIZATION = "visualization", _("Visualization")
+    WRITING_ORIGINAL_DRAFT = "writing-original-draft", _("Writing – original draft")
+    WRITING_REVIEW_EDITING = "writing-review-editing", _("Writing – review & editing")
+
+
+class ContributionDegree(models.TextChoices):
+    LEAD = "lead", _("Lead")
+    EQUAL = "equal", _("Equal")
+    SUPPORTING = "supporting", _("Supporting")
+
+
+class Contribution(models.Model):
+    """A role-tagged contribution by a Person to a credited object.
+
+    Generic relation so one model carries credit for Dataset, Collection, and
+    GazetteerRegistryEntry. This is the structured source of truth that
+    supersedes the free-text ``creator``/``contributors`` strings (Phase 2b
+    wires CSL/DataCite output and a submission UI onto it).
+    """
+
+    person = models.ForeignKey(
+        "persons.Person", on_delete=models.PROTECT, related_name="contributions",
+    )
+    role = models.CharField(max_length=32, choices=CreditRole.choices)
+    degree = models.CharField(
+        max_length=10, blank=True, choices=ContributionDegree.choices,
+    )
+    is_corresponding = models.BooleanField(default=False)
+    order = models.PositiveSmallIntegerField(default=0)
+
+    # target: Dataset | Collection | GazetteerRegistryEntry (generic FK).
+    # object_id is CharField (not PositiveInteger) so it can hold both the
+    # integer PKs of Dataset/Collection and the string PK of
+    # GazetteerRegistryEntry (e.g. "gn", "whg:1234").
+    content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
+    object_id = models.CharField(max_length=64)
+    target = GenericForeignKey("content_type", "object_id")
+
+    class Meta:
+        ordering = ["order"]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["person", "role", "content_type", "object_id"],
+                name="unique_contribution",
+            ),
+        ]
+        indexes = [
+            models.Index(fields=["content_type", "object_id"],
+                         name="contribution_target_idx"),
+        ]
+
+    @property
+    def credit_uri(self):
+        return f"https://credit.niso.org/contributor-roles/{self.role}/"
+
+    def __str__(self):
+        return f"{self.person} — {self.get_role_display()}"

--- a/persons/tests.py
+++ b/persons/tests.py
@@ -1,3 +1,61 @@
+from django.db import IntegrityError, transaction
 from django.test import TestCase
 
-# Create your tests here.
+from api.models import GazetteerRegistryEntry
+from persons.models import Person, Contribution, CreditRole
+
+
+class CreditRoleTests(TestCase):
+    def test_fourteen_roles(self):
+        self.assertEqual(len(CreditRole.choices), 14)
+
+    def test_slug_format(self):
+        # Canonical CRediT slugs: lowercase words joined by single hyphens.
+        for value, _label in CreditRole.choices:
+            self.assertRegex(value, r"^[a-z]+(-[a-z]+)*$")
+
+
+class ContributionTests(TestCase):
+    def setUp(self):
+        self.person = Person.objects.create(family="Mostern", given="Ruth")
+
+    def _contrib(self, target, role=CreditRole.DATA_CURATION):
+        return Contribution.objects.create(person=self.person, role=role, target=target)
+
+    def test_target_int_pk(self):
+        # A second Person stands in for an integer-PK credited object.
+        target = Person.objects.create(family="Grossner", given="Karl")
+        c = self._contrib(target)
+        reloaded = Contribution.objects.get(pk=c.pk)
+        self.assertEqual(reloaded.target, target)
+        self.assertEqual(reloaded.object_id, str(target.pk))
+
+    def test_target_string_pk(self):
+        # GazetteerRegistryEntry has a CharField PK ("gn") — exercises the
+        # CharField object_id that lets one generic FK span mixed PK types.
+        gaz = GazetteerRegistryEntry.objects.create(
+            id="gn", name="GeoNames", namespace="gn", entry_class="authority",
+        )
+        c = self._contrib(gaz, role=CreditRole.RESOURCES)
+        reloaded = Contribution.objects.get(pk=c.pk)
+        self.assertEqual(reloaded.target, gaz)
+        self.assertEqual(reloaded.object_id, "gn")
+
+    def test_credit_uri(self):
+        c = self._contrib(self.person, role=CreditRole.SOFTWARE)
+        self.assertEqual(c.credit_uri,
+                         "https://credit.niso.org/contributor-roles/software/")
+
+    def test_unique_constraint(self):
+        target = Person.objects.create(family="Gadd", given="Stephen")
+        self._contrib(target, role=CreditRole.SOFTWARE)
+        with self.assertRaises(IntegrityError):
+            with transaction.atomic():
+                self._contrib(target, role=CreditRole.SOFTWARE)
+
+    def test_same_person_different_role_allowed(self):
+        target = Person.objects.create(family="Gadd", given="Stephen")
+        self._contrib(target, role=CreditRole.SOFTWARE)
+        self._contrib(target, role=CreditRole.DATA_CURATION)  # no error
+        self.assertEqual(
+            Contribution.objects.filter(object_id=str(target.pk)).count(), 2)

--- a/persons/tests.py
+++ b/persons/tests.py
@@ -33,13 +33,16 @@ class ContributionTests(TestCase):
     def test_target_string_pk(self):
         # GazetteerRegistryEntry has a CharField PK ("gn") — exercises the
         # CharField object_id that lets one generic FK span mixed PK types.
+        # Use a sub-namespaced id (and one not seeded by api's data migration)
+        # to exercise a non-integer PK in object_id.
         gaz = GazetteerRegistryEntry.objects.create(
-            id="gn", name="GeoNames", namespace="gn", entry_class="authority",
+            id="whg:credit-test", name="Credit Test", namespace="whg",
+            entry_class="dataset",
         )
         c = self._contrib(gaz, role=CreditRole.RESOURCES)
         reloaded = Contribution.objects.get(pk=c.pk)
         self.assertEqual(reloaded.target, gaz)
-        self.assertEqual(reloaded.object_id, "gn")
+        self.assertEqual(reloaded.object_id, "whg:credit-test")
 
     def test_credit_uri(self):
         c = self._contrib(self.person, role=CreditRole.SOFTWARE)


### PR DESCRIPTION
Phase 2a of the citations/licences/CRediT work — the **foundation** for CRediT contributor roles (issue [place#99](https://github.com/WorldHistoricalGazetteer/place/issues/99)). Design: `developer/plan-citations-licences-credit.prompt.md` (§3.3); plan: `developer/plan-citations-phase2-credit.prompt.md`.

## What this adds (additive, low-risk)
- **`persons.CreditRole`** — `TextChoices` of the 14 NISO CRediT roles, values = canonical CRediT slugs (so `https://credit.niso.org/contributor-roles/<slug>/` is derivable).
- **`persons.Contribution`** — a role-tagged contribution by a `Person` to a credited object via a **generic relation**, so one model carries credit for **Dataset, Collection, *and* GazetteerRegistryEntry**. Fields: `role`, `degree` (lead/equal/supporting), `is_corresponding`, `order`; `UniqueConstraint(person, role, content_type, object_id)`; `credit_uri` property.
- `object_id` is a **CharField** (not PositiveInteger) so it spans both the integer PKs of Dataset/Collection and the **string PK** of GazetteerRegistryEntry (e.g. `"gn"`, `"whg:1234"`).
- Admin for `Contribution` (autocomplete person). `persons.Person` already had first-class `orcid`/`affiliation`, so no Person change was needed.

## Not in this PR (Phase 2b — touches live CSL/DOI/UI, separate PR)
CSL formatter reading Contributions, DataCite `contributors` array, a free-text→Contribution importer, and the submission UI. Phase 2a is foundation only — **no change to existing CSL/DOI/templates**, so nothing in the live render/DOI path moves.

## Validation
`python3 manage.py test persons` → **7/7 OK** (one-off container vs dev Postgres, throwaway test DB), and `makemigrations persons --check` → "No changes detected" (migration matches model). Migration `persons/0003_contribution` is additive (new table only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
