### PR TITLE
fix(credit): robust contributor importer (duplicate Person handling)

### DIFF
--- a/persons/management/commands/import_freetext_contributors.py
+++ b/persons/management/commands/import_freetext_contributors.py
@@ -7,6 +7,7 @@ Data curation (editable afterwards). Run with --dry-run to preview counts.
 """
 from django.contrib.contenttypes.models import ContentType
 from django.core.management.base import BaseCommand
+from django.db import transaction
 
 from persons.models import Person, Contribution, CreditRole
 from utils.csl_citation_formatter import parse_names
@@ -18,22 +19,31 @@ FIELD_ROLES = [
 ]
 
 
-def _get_or_create_person(name):
-    """name is a CSL dict from parse_names: {family, given[, ORCID]} or {literal}."""
+def _get_person(name):
+    """name is a CSL dict from parse_names: {family, given[, ORCID]} or {literal}.
+
+    Uses filter().first() rather than get_or_create so that pre-existing
+    DUPLICATE Person rows (same family/given) don't raise MultipleObjectsReturned
+    — the first match is reused.
+    """
     literal = name.get("literal")
     if literal:
-        person, _ = Person.objects.get_or_create(literal=literal)
-        return person
+        return (Person.objects.filter(literal=literal).first()
+                or Person.objects.create(literal=literal))
+
     orcid = (name.get("ORCID") or "").replace("https://orcid.org/", "") or None
-    lookup = {"family": name.get("family") or None, "given": name.get("given") or None}
     if orcid:
-        # ORCiD is unique; match on it first to avoid duplicate people.
         existing = Person.objects.filter(orcid=orcid).first()
         if existing:
             return existing
-        lookup["orcid"] = orcid
-    person, _ = Person.objects.get_or_create(**lookup)
-    return person
+
+    family = name.get("family") or None
+    given = name.get("given") or None
+    existing = Person.objects.filter(family=family, given=given).first()
+    if existing:
+        return existing
+    return Person.objects.create(
+        family=family, given=given, **({"orcid": orcid} if orcid else {}))
 
 
 class Command(BaseCommand):
@@ -50,31 +60,40 @@ class Command(BaseCommand):
         dry = opts["dry_run"]
         people = contributions = 0
 
+        errors = 0
         for Model in (Dataset, Collection):
             ct = ContentType.objects.get_for_model(Model)
             for obj in Model.objects.all():
                 if Contribution.objects.filter(content_type=ct, object_id=str(obj.pk)).exists():
                     continue
-                order = 0
-                for field, role in FIELD_ROLES:
-                    text = getattr(obj, field, None)
-                    if not text:
-                        continue
-                    for name in parse_names(text):
-                        order += 1
-                        if dry:
-                            contributions += 1
-                            continue
-                        person = _get_or_create_person(name)
-                        people += 1
-                        _, created = Contribution.objects.get_or_create(
-                            person=person, role=role, content_type=ct,
-                            object_id=str(obj.pk), defaults={"order": order},
-                        )
-                        contributions += int(created)
+                try:
+                    # Per-object atomic so a bad row never leaves a half-imported
+                    # object and never aborts the whole run.
+                    with transaction.atomic():
+                        order = 0
+                        for field, role in FIELD_ROLES:
+                            text = getattr(obj, field, None)
+                            if not text:
+                                continue
+                            for name in parse_names(text):
+                                order += 1
+                                if dry:
+                                    contributions += 1
+                                    continue
+                                person = _get_person(name)
+                                people += 1
+                                _, created = Contribution.objects.get_or_create(
+                                    person=person, role=role, content_type=ct,
+                                    object_id=str(obj.pk), defaults={"order": order},
+                                )
+                                contributions += int(created)
+                except Exception as e:
+                    errors += 1
+                    self.stderr.write(
+                        f"  skipped {Model.__name__} {obj.pk}: {e}")
 
         verb = "Would create" if dry else "Created"
         self.stdout.write(self.style.SUCCESS(
             f"{verb} {contributions} contributions"
-            + ("" if dry else f" (touched {people} people)")
+            + ("" if dry else f" (touched {people} people, {errors} objects skipped)")
         ))

--- a/persons/tests.py
+++ b/persons/tests.py
@@ -138,3 +138,14 @@ class CitationWiringTests(TestCase):
         # idempotent
         call_command("import_freetext_contributors")
         self.assertEqual(contribs.count(), 3)
+
+    def test_importer_handles_duplicate_persons(self):
+        # Pre-existing duplicate Person rows (same name, null orcid) must not
+        # raise MultipleObjectsReturned — the importer reuses the first.
+        Person.objects.create(family="Mostern", given="Ruth")
+        Person.objects.create(family="Mostern", given="Ruth")
+        call_command("import_freetext_contributors")  # must not raise
+        from django.contrib.contenttypes.models import ContentType
+        ct = ContentType.objects.get_for_model(self.ds.__class__)
+        self.assertTrue(Contribution.objects.filter(
+            content_type=ct, object_id=str(self.ds.pk)).exists())


### PR DESCRIPTION
The prod run of `import_freetext_contributors` hit `Person.MultipleObjectsReturned` (pre-existing duplicate Person rows with the same name break `get_or_create`). Switches person lookup to `filter().first()` reuse, wraps each object in `transaction.atomic()` with per-object error isolation (skip + warn, never abort or leave a half-imported object), and reports the skipped count. Regression test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)