### PR TITLE
feat(credit): admin GenericInline for editing Contributions (Phase 2b)

### DIFF
--- a/collection/admin.py
+++ b/collection/admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 from .models import *
+from persons.admin import ContributionInline
 
 class CollectionAdmin(admin.ModelAdmin):
     list_display = ('title', 'id', 'description', 'owner_id', 'status')
@@ -11,6 +12,7 @@ class CollectionAdmin(admin.ModelAdmin):
     autocomplete_fields = ('license',)
     list_filter = ('status','collection_class')
     search_fields = ('username', 'name')
+    inlines = [ContributionInline]
 
 admin.site.register(Collection, CollectionAdmin)
 

--- a/datasets/admin.py
+++ b/datasets/admin.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from .models import Dataset, DatasetFile, Hit
 from guardian.admin import GuardedModelAdmin
+from persons.admin import ContributionInline
 
 # class DatasetAdmin(GuardedModelAdmin):
 class DatasetAdmin(admin.ModelAdmin):
@@ -12,6 +13,7 @@ class DatasetAdmin(admin.ModelAdmin):
     readonly_fields = ('id','label','owner','create_date','numrows','numlinked','total_links',)
     autocomplete_fields = ('license',)
     search_fields = ('title','label')
+    inlines = [ContributionInline]
 admin.site.register(Dataset, DatasetAdmin)
 # admin.site.register(Dataset)
 

--- a/persons/admin.py
+++ b/persons/admin.py
@@ -1,5 +1,17 @@
 from django.contrib import admin
+from django.contrib.contenttypes.admin import GenericTabularInline
 from .models import Person, EmailAddress, Contribution
+
+
+class ContributionInline(GenericTabularInline):
+    """Edit CRediT contributions inline on the credited object's admin page.
+
+    Reused by Dataset and Collection admin (and usable on any credited model).
+    """
+    model = Contribution
+    extra = 1
+    autocomplete_fields = ("person",)
+    fields = ("person", "role", "degree", "is_corresponding", "order")
 
 class EmailAddressInline(admin.TabularInline):
     model = Person.emails.through


### PR DESCRIPTION
Phase 2b — a robust editing surface for CRediT contributions: a Django **GenericInline** (`persons.admin.ContributionInline`) wired into the **Dataset** and **Collection** admin. Staff/owners can add/remove/edit contributions (person autocomplete + role/degree/corresponding/order dropdowns) directly on the credited object.

- **Admin-only**, additive — no model, migration, or public-template change. `manage.py check` clean.
- Complements the now-live read path: the 387 imported contributions already back the CSL author list and DataCite `contributors`; this makes them curatable.

## Remaining (scoped follow-on): public contributor-entry widget
The design's §4.6 public submission UI — repeatable person+ORCID+affiliation × CRediT-role rows on the **dataset upload/validate** and **collection** forms — is a larger frontend effort (dynamic formset + JS, touching the production submission flow) and is best done as its own focused PR (with frontend design iteration). This PR delivers complete editing via the admin in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
