### PR TITLE
feat(credit): collection-side contributor widget + shared include/helper (Phase 2b)

### DIFF
--- a/collection/templates/collection/ds_collection_build.html
+++ b/collection/templates/collection/ds_collection_build.html
@@ -163,6 +163,7 @@
           </div> {# col-sm-7 #}
         </div> {# row #}
       </form>
+      {% if object.id %}{% include 'includes/_credit_contributors.html' %}{% endif %}
       <div id="linkform_popup" class="pop">
         <form action="#" method="post">
           {% csrf_token %}

--- a/collection/templates/collection/place_collection_build.html
+++ b/collection/templates/collection/place_collection_build.html
@@ -244,6 +244,7 @@
             </div>
             {# row #}
           </form>
+          {% if object.id %}{% include 'includes/_credit_contributors.html' %}{% endif %}
           <div id="linkform_popup" class="pop">
             <form action="#" method="post">
               {% csrf_token %}

--- a/collection/urls.py
+++ b/collection/urls.py
@@ -46,6 +46,8 @@ urlpatterns = [
 
     # UTILITY
     path('<int:id>/citation', views.collection_citation, name='collection-citation'),
+    path('<int:id>/contributions/add', views.collection_contribution_add, name='coll_contribution_add'),
+    path('<int:id>/contributions/<int:cid>/delete', views.collection_contribution_delete, name='coll_contribution_delete'),
     path('list_ds/', views.ListDatasetView.as_view(), name='list-ds'),
     path('add_ds/<int:coll_id>/<int:ds_id>', views.add_dataset, name='add-ds'),
     path('add_dsplaces/<int:coll_id>/<int:ds_id>', views.add_dataset_places, name='add-dsplaces'),

--- a/collection/views.py
+++ b/collection/views.py
@@ -14,7 +14,8 @@ from django.core.cache import cache
 from django.db.models import F, Min, Max
 from django.db.models.functions import Coalesce
 from django.forms.models import inlineformset_factory
-from django.http import JsonResponse, HttpResponseRedirect, Http404, HttpResponseServerError
+from django.contrib.auth.decorators import login_required
+from django.http import JsonResponse, HttpResponseRedirect, Http404, HttpResponseServerError, HttpResponseForbidden
 from django.conf import settings
 from django.shortcuts import get_object_or_404, redirect
 from django.views.decorators.http import require_POST
@@ -963,6 +964,7 @@ class PlaceCollectionUpdateView(LoginRequiredMixin, UpdateView):
         context['created'] = self.object.create_date.strftime("%Y-%m-%d")
         # context['whgteam'] = User.objects.filter(groups__name='whg_team')
 
+        context.update(_credit_context(self.object, self.request.user))
         return context
 
 
@@ -1303,6 +1305,7 @@ class DatasetCollectionUpdateView(UpdateView):
         # context['visParameters'] = json.dumps(vis_parameters)
         context['vis_parameters_dict'] = vis_parameters
 
+        context.update(_credit_context(self.object, self.request.user))
         return context
 
 
@@ -1397,3 +1400,49 @@ class CollectionDeleteView(DeleteView):
 
     def get_success_url(self):
         return reverse('dashboard')
+
+
+# ---------------------------------------------------------------------------
+# CRediT contributor editing (Phase 2b public widget)
+# ---------------------------------------------------------------------------
+
+def _credit_context(obj, user):
+    """Context for the reusable includes/_credit_contributors.html widget."""
+    from django.contrib.contenttypes.models import ContentType
+    from persons.models import Contribution, CreditRole, ContributionDegree
+    ct = ContentType.objects.get_for_model(obj.__class__)
+    return {
+        'contributions': (Contribution.objects
+                          .filter(content_type=ct, object_id=str(obj.pk))
+                          .select_related('person').order_by('order')),
+        'credit_roles': CreditRole.choices,
+        'contribution_degrees': ContributionDegree.choices,
+        'can_edit_credit': user.is_staff or user in obj.owners,
+        'contrib_base': f"/collections/{obj.pk}/contributions",
+    }
+
+
+def _user_can_edit_collection(user, coll):
+    return user.is_staff or user in coll.owners
+
+
+@login_required
+@require_POST
+def collection_contribution_add(request, id):
+    """Create a CRediT Contribution for a collection. Owner/staff only."""
+    from persons.contributions import add_contribution
+    coll = get_object_or_404(Collection, id=id)
+    if not _user_can_edit_collection(request.user, coll):
+        return HttpResponseForbidden("Not permitted")
+    return add_contribution(request, coll)
+
+
+@login_required
+@require_POST
+def collection_contribution_delete(request, id, cid):
+    """Delete a CRediT Contribution from a collection. Owner/staff only."""
+    from persons.contributions import delete_contribution
+    coll = get_object_or_404(Collection, id=id)
+    if not _user_can_edit_collection(request.user, coll):
+        return HttpResponseForbidden("Not permitted")
+    return delete_contribution(request, coll, cid)

--- a/datasets/templates/datasets/ds_metadata.html
+++ b/datasets/templates/datasets/ds_metadata.html
@@ -306,48 +306,7 @@
             {% include 'main/download_modal.html' with object=ds entity_type='dataset' entity_prefix='dataset' %}
 {#          {% endif %} <!-- owner or superuser -->#}
 
-            <!-- CRediT Contributors (Phase 2b) -->
-            <div class="mt-3" id="credit-contributors" data-dsid="{{ ds.id }}">
-              <h6 class="fw-bold mb-1">CRediT Contributors
-                <a href="https://credit.niso.org/" target="_blank" rel="noopener"
-                   data-bs-toggle="tooltip" data-bs-title="Contributor Roles Taxonomy">
-                  <i class="fas fa-question-circle fa-xs"></i></a>
-              </h6>
-              <ul class="list-unstyled mb-2" id="contrib-list">
-                {% for c in contributions %}
-                  <li data-cid="{{ c.id }}" class="mb-1">
-                    <span class="fw-semibold">{{ c.person }}</span>{% if c.person.orcid %}
-                      <a href="https://orcid.org/{{ c.person.orcid }}" target="_blank" rel="noopener" title="ORCiD"><i class="fab fa-orcid"></i></a>{% endif %}
-                    — {{ c.get_role_display }}{% if c.degree %} ({{ c.get_degree_display }}){% endif %}{% if c.is_corresponding %} <span class="badge bg-light text-dark border">corresponding</span>{% endif %}
-                    {% if can_edit_credit %}<a href="#" class="contrib-del text-danger ms-1" title="Remove"><i class="fas fa-times fa-xs"></i></a>{% endif %}
-                  </li>
-                {% empty %}
-                  <li class="text-muted small" id="contrib-empty">No structured contributors yet.</li>
-                {% endfor %}
-              </ul>
-              {% if can_edit_credit %}
-              <form id="contrib-add-form" class="row g-1 small align-items-center">
-                <div class="col-12 col-md-3"><input type="text" name="name" class="form-control form-control-sm" placeholder="Name or [Organisation]" required></div>
-                <div class="col-6 col-md-2"><input type="text" name="orcid" class="form-control form-control-sm" placeholder="ORCiD (optional)"></div>
-                <div class="col-6 col-md-2"><input type="text" name="affiliation" class="form-control form-control-sm" placeholder="Affiliation"></div>
-                <div class="col-6 col-md-2">
-                  <select name="role" class="form-select form-select-sm" required>
-                    <option value="">Role…</option>
-                    {% for val, label in credit_roles %}<option value="{{ val }}">{{ label }}</option>{% endfor %}
-                  </select>
-                </div>
-                <div class="col-4 col-md-1">
-                  <select name="degree" class="form-select form-select-sm" title="Degree of contribution">
-                    <option value="">—</option>
-                    {% for val, label in contribution_degrees %}<option value="{{ val }}">{{ label }}</option>{% endfor %}
-                  </select>
-                </div>
-                <div class="col-3 col-md-1"><label class="small mb-0"><input type="checkbox" name="is_corresponding"> corr.</label></div>
-                <div class="col-auto"><button type="submit" class="btn btn-sm btn-primary">Add</button></div>
-                <div class="col-12"><span id="contrib-error" class="text-danger small"></span></div>
-              </form>
-              {% endif %}
-            </div>
+            {% include 'includes/_credit_contributors.html' %}
         </div> <!-- ds_info -->
       </div> <!-- ds_details -->
       </div> <!-- row -->
@@ -403,76 +362,6 @@
     /* TODO: THESE ARE REFERENCED IN JAVASCRIPT BUT NOT SET IN THE VIEW */
     var context_status = '{{ status }}';
     var context_context = '{{ context }}';
-</script>
-
-<script>
-// CRediT contributors widget (Phase 2b)
-(function () {
-  var root = document.getElementById('credit-contributors');
-  if (!root) return;
-  var dsId = root.getAttribute('data-dsid');
-  var meta = document.querySelector('meta[name="csrf-token"]');
-  var csrf = meta ? meta.getAttribute('content') : '';
-  var list = document.getElementById('contrib-list');
-  var form = document.getElementById('contrib-add-form');
-  var errEl = document.getElementById('contrib-error');
-
-  function onDelete(e) {
-    e.preventDefault();
-    var li = e.target.closest('li');
-    var cid = li.getAttribute('data-cid');
-    fetch('/datasets/' + dsId + '/contributions/' + cid + '/delete',
-          {method: 'POST', headers: {'X-CSRFToken': csrf}})
-      .then(function (r) { if (r.ok) li.remove(); });
-  }
-  function bindDelete(scope) {
-    (scope || document).querySelectorAll('.contrib-del')
-      .forEach(function (a) { a.onclick = onDelete; });
-  }
-  bindDelete();
-
-  if (form) {
-    form.addEventListener('submit', function (e) {
-      e.preventDefault();
-      errEl.textContent = '';
-      fetch('/datasets/' + dsId + '/contributions/add',
-            {method: 'POST', headers: {'X-CSRFToken': csrf}, body: new FormData(form)})
-        .then(function (r) { return r.json().then(function (d) { return {ok: r.ok, d: d}; }); })
-        .then(function (res) {
-          if (!res.ok) { errEl.textContent = res.d.error || 'Error adding contributor.'; return; }
-          var d = res.d;
-          var empty = document.getElementById('contrib-empty');
-          if (empty) empty.remove();
-          var li = document.createElement('li');
-          li.setAttribute('data-cid', d.id);
-          li.className = 'mb-1';
-          // User-entered name via textContent (no innerHTML) to avoid XSS.
-          var nameSpan = document.createElement('span');
-          nameSpan.className = 'fw-semibold';
-          nameSpan.textContent = d.person;
-          li.appendChild(nameSpan);
-          if (d.orcid) {
-            li.insertAdjacentHTML('beforeend',
-              ' <a href="https://orcid.org/' + encodeURIComponent(d.orcid) +
-              '" target="_blank" rel="noopener" title="ORCiD"><i class="fab fa-orcid"></i></a>');
-          }
-          var tail = ' — ' + d.role + (d.degree ? ' (' + d.degree + ')' : '') +
-                     (d.is_corresponding ? '' : '');
-          li.appendChild(document.createTextNode(tail));
-          if (d.is_corresponding) {
-            li.insertAdjacentHTML('beforeend',
-              ' <span class="badge bg-light text-dark border">corresponding</span>');
-          }
-          li.insertAdjacentHTML('beforeend',
-            ' <a href="#" class="contrib-del text-danger ms-1" title="Remove"><i class="fas fa-times fa-xs"></i></a>');
-          list.appendChild(li);
-          bindDelete(li);
-          form.reset();
-        })
-        .catch(function () { errEl.textContent = 'Network error.'; });
-    });
-  }
-})();
 </script>
 
 {% endblock %}

--- a/datasets/views.py
+++ b/datasets/views.py
@@ -633,6 +633,7 @@ class DatasetMetadataView(LoginRequiredMixin, UpdateView, DatasetContextMixin, A
         context['contribution_degrees'] = ContributionDegree.choices
         context['can_edit_credit'] = (self.request.user.is_staff
                                       or self.request.user in ds.owners)
+        context['contrib_base'] = f"/datasets/{ds.id}/contributions"
 
         return context
 
@@ -1952,79 +1953,23 @@ def _user_can_edit_dataset(user, ds):
     return user.is_staff or user in ds.owners
 
 
-def _invalidate_citation_cache(ds):
-    try:
-        caches['property_cache'].delete(f"dataset:{ds.pk}:citation_csl")
-    except Exception:
-        pass
-
-
 @login_required
 @require_POST
 def dataset_contribution_add(request, id):
-    """Create a CRediT Contribution (and Person) for a dataset. Owner/staff only."""
-    from django.contrib.contenttypes.models import ContentType
-    from persons.models import Contribution, CreditRole, ContributionDegree
-    from persons.utils import resolve_person
-    from utils.csl_citation_formatter import parse_names
-
+    """Create a CRediT Contribution for a dataset. Owner/staff only."""
+    from persons.contributions import add_contribution
     ds = get_object_or_404(Dataset, id=id)
     if not _user_can_edit_dataset(request.user, ds):
         return HttpResponseForbidden("Not permitted")
-
-    name_text = (request.POST.get('name') or '').strip()
-    role = request.POST.get('role') or ''
-    if not name_text:
-        return JsonResponse({'error': 'Name is required.'}, status=400)
-    if role not in CreditRole.values:
-        return JsonResponse({'error': 'A valid CRediT role is required.'}, status=400)
-
-    degree = request.POST.get('degree') or ''
-    if degree and degree not in ContributionDegree.values:
-        degree = ''
-    is_corr = request.POST.get('is_corresponding') in ('true', 'on', '1', 'True')
-    affiliation = (request.POST.get('affiliation') or '').strip() or None
-    orcid_in = (request.POST.get('orcid') or '').strip() or None
-
-    parsed = parse_names(name_text)
-    if not parsed:
-        return JsonResponse({'error': 'Could not parse the name.'}, status=400)
-    name = parsed[0]
-    if orcid_in and 'literal' not in name:
-        name['ORCID'] = orcid_in
-    person = resolve_person(name, affiliation=affiliation)
-
-    ct = ContentType.objects.get_for_model(Dataset)
-    order = Contribution.objects.filter(content_type=ct, object_id=str(ds.id)).count()
-    contrib, created = Contribution.objects.get_or_create(
-        person=person, role=role, content_type=ct, object_id=str(ds.id),
-        defaults={'degree': degree, 'is_corresponding': is_corr, 'order': order},
-    )
-    if not created:
-        return JsonResponse({'error': 'That person already has that role here.'}, status=409)
-    _invalidate_citation_cache(ds)
-    return JsonResponse({
-        'id': contrib.id,
-        'person': str(person),
-        'orcid': person.orcid or '',
-        'affiliation': person.affiliation or '',
-        'role': contrib.get_role_display(),
-        'degree': contrib.get_degree_display() if contrib.degree else '',
-        'is_corresponding': contrib.is_corresponding,
-    })
+    return add_contribution(request, ds)
 
 
 @login_required
 @require_POST
 def dataset_contribution_delete(request, id, cid):
     """Delete a CRediT Contribution from a dataset. Owner/staff only."""
-    from django.contrib.contenttypes.models import ContentType
-    from persons.models import Contribution
-
+    from persons.contributions import delete_contribution
     ds = get_object_or_404(Dataset, id=id)
     if not _user_can_edit_dataset(request.user, ds):
         return HttpResponseForbidden("Not permitted")
-    ct = ContentType.objects.get_for_model(Dataset)
-    Contribution.objects.filter(id=cid, content_type=ct, object_id=str(ds.id)).delete()
-    _invalidate_citation_cache(ds)
-    return JsonResponse({'ok': True})
+    return delete_contribution(request, ds, cid)

--- a/main/templates/includes/_credit_contributors.html
+++ b/main/templates/includes/_credit_contributors.html
@@ -1,0 +1,116 @@
+{% comment %}
+Reusable CRediT contributors editor (Phase 2b). Required context:
+  contributions          queryset of persons.Contribution for the object
+  credit_roles           CreditRole.choices
+  contribution_degrees   ContributionDegree.choices
+  can_edit_credit        bool (owner/staff)
+  contrib_base           URL prefix, e.g. "/datasets/123/contributions"
+                         (endpoints: {base}/add and {base}/{cid}/delete)
+{% endcomment %}
+<div class="mt-3" id="credit-contributors" data-contrib-base="{{ contrib_base }}">
+  <h6 class="fw-bold mb-1">CRediT Contributors
+    <a href="https://credit.niso.org/" target="_blank" rel="noopener"
+       data-bs-toggle="tooltip" data-bs-title="Contributor Roles Taxonomy">
+      <i class="fas fa-question-circle fa-xs"></i></a>
+  </h6>
+  <ul class="list-unstyled mb-2" id="contrib-list">
+    {% for c in contributions %}
+      <li data-cid="{{ c.id }}" class="mb-1">
+        <span class="fw-semibold">{{ c.person }}</span>{% if c.person.orcid %}
+          <a href="https://orcid.org/{{ c.person.orcid }}" target="_blank" rel="noopener" title="ORCiD"><i class="fab fa-orcid"></i></a>{% endif %}
+        — {{ c.get_role_display }}{% if c.degree %} ({{ c.get_degree_display }}){% endif %}{% if c.is_corresponding %} <span class="badge bg-light text-dark border">corresponding</span>{% endif %}
+        {% if can_edit_credit %}<a href="#" class="contrib-del text-danger ms-1" title="Remove"><i class="fas fa-times fa-xs"></i></a>{% endif %}
+      </li>
+    {% empty %}
+      <li class="text-muted small" id="contrib-empty">No structured contributors yet.</li>
+    {% endfor %}
+  </ul>
+  {% if can_edit_credit %}
+  <form id="contrib-add-form" class="row g-1 small align-items-center">
+    <div class="col-12 col-md-3"><input type="text" name="name" class="form-control form-control-sm" placeholder="Name or [Organisation]" required></div>
+    <div class="col-6 col-md-2"><input type="text" name="orcid" class="form-control form-control-sm" placeholder="ORCiD (optional)"></div>
+    <div class="col-6 col-md-2"><input type="text" name="affiliation" class="form-control form-control-sm" placeholder="Affiliation"></div>
+    <div class="col-6 col-md-2">
+      <select name="role" class="form-select form-select-sm" required>
+        <option value="">Role…</option>
+        {% for val, label in credit_roles %}<option value="{{ val }}">{{ label }}</option>{% endfor %}
+      </select>
+    </div>
+    <div class="col-4 col-md-1">
+      <select name="degree" class="form-select form-select-sm" title="Degree of contribution">
+        <option value="">—</option>
+        {% for val, label in contribution_degrees %}<option value="{{ val }}">{{ label }}</option>{% endfor %}
+      </select>
+    </div>
+    <div class="col-3 col-md-1"><label class="small mb-0"><input type="checkbox" name="is_corresponding"> corr.</label></div>
+    <div class="col-auto"><button type="submit" class="btn btn-sm btn-primary">Add</button></div>
+    <div class="col-12"><span id="contrib-error" class="text-danger small"></span></div>
+  </form>
+  {% endif %}
+</div>
+<script>
+(function () {
+  var root = document.getElementById('credit-contributors');
+  if (!root || root.dataset.creditBound) return;
+  root.dataset.creditBound = '1';
+  var base = root.getAttribute('data-contrib-base');
+  var meta = document.querySelector('meta[name="csrf-token"]');
+  var csrf = meta ? meta.getAttribute('content') : '';
+  var list = document.getElementById('contrib-list');
+  var form = document.getElementById('contrib-add-form');
+  var errEl = document.getElementById('contrib-error');
+
+  function onDelete(e) {
+    e.preventDefault();
+    var li = e.target.closest('li');
+    fetch(base + '/' + li.getAttribute('data-cid') + '/delete',
+          {method: 'POST', headers: {'X-CSRFToken': csrf}})
+      .then(function (r) { if (r.ok) li.remove(); });
+  }
+  function bindDelete(scope) {
+    (scope || document).querySelectorAll('.contrib-del')
+      .forEach(function (a) { a.onclick = onDelete; });
+  }
+  bindDelete();
+
+  if (form) {
+    form.addEventListener('submit', function (e) {
+      e.preventDefault();
+      errEl.textContent = '';
+      fetch(base + '/add',
+            {method: 'POST', headers: {'X-CSRFToken': csrf}, body: new FormData(form)})
+        .then(function (r) { return r.json().then(function (d) { return {ok: r.ok, d: d}; }); })
+        .then(function (res) {
+          if (!res.ok) { errEl.textContent = res.d.error || 'Error adding contributor.'; return; }
+          var d = res.d;
+          var empty = document.getElementById('contrib-empty');
+          if (empty) empty.remove();
+          var li = document.createElement('li');
+          li.setAttribute('data-cid', d.id);
+          li.className = 'mb-1';
+          var nameSpan = document.createElement('span');
+          nameSpan.className = 'fw-semibold';
+          nameSpan.textContent = d.person;  // user input -> textContent (no XSS)
+          li.appendChild(nameSpan);
+          if (d.orcid) {
+            li.insertAdjacentHTML('beforeend',
+              ' <a href="https://orcid.org/' + encodeURIComponent(d.orcid) +
+              '" target="_blank" rel="noopener" title="ORCiD"><i class="fab fa-orcid"></i></a>');
+          }
+          li.appendChild(document.createTextNode(
+            ' — ' + d.role + (d.degree ? ' (' + d.degree + ')' : '')));
+          if (d.is_corresponding) {
+            li.insertAdjacentHTML('beforeend',
+              ' <span class="badge bg-light text-dark border">corresponding</span>');
+          }
+          li.insertAdjacentHTML('beforeend',
+            ' <a href="#" class="contrib-del text-danger ms-1" title="Remove"><i class="fas fa-times fa-xs"></i></a>');
+          list.appendChild(li);
+          bindDelete(li);
+          form.reset();
+        })
+        .catch(function () { errEl.textContent = 'Network error.'; });
+    });
+  }
+})();
+</script>

--- a/persons/contributions.py
+++ b/persons/contributions.py
@@ -1,0 +1,69 @@
+"""Shared CRediT-contribution add/delete logic for the public widget, reused by
+the dataset and collection metadata/build pages. Callers MUST check edit
+permission on the target object before delegating here."""
+from django.contrib.contenttypes.models import ContentType
+from django.core.cache import caches
+from django.http import JsonResponse
+
+from persons.models import Contribution, CreditRole, ContributionDegree
+from persons.utils import resolve_person
+from utils.csl_citation_formatter import parse_names
+
+
+def invalidate_citation_cache(obj):
+    try:
+        caches['property_cache'].delete(
+            f"{obj._meta.model_name}:{obj.pk}:citation_csl")
+    except Exception:
+        pass
+
+
+def add_contribution(request, obj):
+    """Create a Contribution (and Person) for ``obj`` from POST data."""
+    name_text = (request.POST.get('name') or '').strip()
+    role = request.POST.get('role') or ''
+    if not name_text:
+        return JsonResponse({'error': 'Name is required.'}, status=400)
+    if role not in CreditRole.values:
+        return JsonResponse({'error': 'A valid CRediT role is required.'}, status=400)
+
+    degree = request.POST.get('degree') or ''
+    if degree and degree not in ContributionDegree.values:
+        degree = ''
+    is_corr = request.POST.get('is_corresponding') in ('true', 'on', '1', 'True')
+    affiliation = (request.POST.get('affiliation') or '').strip() or None
+    orcid_in = (request.POST.get('orcid') or '').strip() or None
+
+    parsed = parse_names(name_text)
+    if not parsed:
+        return JsonResponse({'error': 'Could not parse the name.'}, status=400)
+    name = parsed[0]
+    if orcid_in and 'literal' not in name:
+        name['ORCID'] = orcid_in
+    person = resolve_person(name, affiliation=affiliation)
+
+    ct = ContentType.objects.get_for_model(obj.__class__)
+    order = Contribution.objects.filter(content_type=ct, object_id=str(obj.pk)).count()
+    contrib, created = Contribution.objects.get_or_create(
+        person=person, role=role, content_type=ct, object_id=str(obj.pk),
+        defaults={'degree': degree, 'is_corresponding': is_corr, 'order': order},
+    )
+    if not created:
+        return JsonResponse({'error': 'That person already has that role here.'}, status=409)
+    invalidate_citation_cache(obj)
+    return JsonResponse({
+        'id': contrib.id,
+        'person': str(person),
+        'orcid': person.orcid or '',
+        'affiliation': person.affiliation or '',
+        'role': contrib.get_role_display(),
+        'degree': contrib.get_degree_display() if contrib.degree else '',
+        'is_corresponding': contrib.is_corresponding,
+    })
+
+
+def delete_contribution(request, obj, cid):
+    ct = ContentType.objects.get_for_model(obj.__class__)
+    Contribution.objects.filter(id=cid, content_type=ct, object_id=str(obj.pk)).delete()
+    invalidate_citation_cache(obj)
+    return JsonResponse({'ok': True})

--- a/persons/tests.py
+++ b/persons/tests.py
@@ -202,3 +202,37 @@ class ContributorEndpointTests(TestCase):
             "name": "[University of Pittsburgh]", "role": "resources"})
         self.assertEqual(r.status_code, 200)
         self.assertTrue(Person.objects.filter(literal="University of Pittsburgh").exists())
+
+
+class CollectionContributorEndpointTests(TestCase):
+    """Phase 2b public widget: collection contribution add/delete endpoints."""
+
+    def setUp(self):
+        from collection.models import Collection
+        doi_patch = patch("collection.signals.doi")
+        doi_patch.start()
+        self.addCleanup(doi_patch.stop)
+        User = get_user_model()
+        self.owner = User.objects.create(username="cowner", email="co@example.com")
+        self.other = User.objects.create(username="cother", email="cx@example.com")
+        self.coll = Collection.objects.create(
+            owner=self.owner, title="C", description="D", collection_class="place")
+        self.add_url = reverse("collection:coll_contribution_add", args=[self.coll.id])
+
+    def test_owner_can_add_and_delete(self):
+        self.client.force_login(self.owner)
+        r = self.client.post(self.add_url, {"name": "Ruth Mostern",
+                                            "role": "conceptualization"})
+        self.assertEqual(r.status_code, 200)
+        data = r.json()
+        self.assertEqual(Contribution.objects.count(), 1)
+        del_url = reverse("collection:coll_contribution_delete",
+                          args=[self.coll.id, data["id"]])
+        self.assertEqual(self.client.post(del_url).status_code, 200)
+        self.assertEqual(Contribution.objects.count(), 0)
+
+    def test_non_owner_forbidden(self):
+        self.client.force_login(self.other)
+        r = self.client.post(self.add_url, {"name": "X", "role": "software"})
+        self.assertEqual(r.status_code, 403)
+        self.assertEqual(Contribution.objects.count(), 0)


### PR DESCRIPTION
Phase 2b — extends the CRediT contributor widget to **collections**, and factors the dataset + collection sides onto shared code.

## Changes
- **`persons.contributions`** — shared `add_contribution` / `delete_contribution` backend (parse → `resolve_person` → `Contribution`, generic citation-cache invalidation). The dataset endpoints are refactored onto it (behaviour unchanged).
- **`includes/_credit_contributors.html`** — reusable widget (markup + `fetch` JS reading a `data-contrib-base` attribute). **`ds_metadata.html` now uses the include** instead of its inline copy (same behaviour).
- **`collection.views`** — `collection_contribution_add` / `_delete` endpoints, gated to `coll.owners` + staff; `_credit_context()` helper; both collection **Update** views pass the credit context; routes added.
- **Both collection build templates** include the widget, gated on `object.id` (so it shows only on existing collections, and sits outside the page forms).

## Safety
- **No model/migration change.** `manage.py check` clean; all 4 affected templates parse clean.
- Owner/staff permission enforced server-side on the collection endpoints.
- Generic cache key `{model}:{pk}:citation_csl` covers both datasets and collections.

## Validation
`manage.py test persons` → **18/18 OK**, including new collection endpoint tests (owner add/delete, non-owner 403; DOI `post_save` mocked). Dataset + collection build templates render-parse cleanly.

## Note
Deploying re-touches the dataset metadata page (now via the shared include — identical behaviour, already verified live). Best to eyeball a collection build page after deploy. This completes the public CRediT submission UI for both datasets and collections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
