### PR TITLE
fix(credit): widget left-column placement, editor note, footer-overlap fix

### DIFF
--- a/datasets/templates/datasets/ds_metadata.html
+++ b/datasets/templates/datasets/ds_metadata.html
@@ -217,6 +217,8 @@
         <input type="hidden" name="label" value="{{ ds.label }}">
         <input type="hidden" name="format" value="dummy">
         <input type="hidden" name="datatype" value="place">
+
+        {% include 'includes/_credit_contributors.html' %}
       </div> <!-- ds_details -->
 
       <div class="col-sm-5 small">
@@ -305,8 +307,6 @@
 
             {% include 'main/download_modal.html' with object=ds entity_type='dataset' entity_prefix='dataset' %}
 {#          {% endif %} <!-- owner or superuser -->#}
-
-            {% include 'includes/_credit_contributors.html' %}
         </div> <!-- ds_info -->
       </div> <!-- ds_details -->
       </div> <!-- row -->

--- a/main/templates/includes/_credit_contributors.html
+++ b/main/templates/includes/_credit_contributors.html
@@ -6,6 +6,9 @@ Reusable CRediT contributors editor (Phase 2b). Required context:
   can_edit_credit        bool (owner/staff)
   contrib_base           URL prefix, e.g. "/datasets/123/contributions"
                          (endpoints: {base}/add and {base}/{cid}/delete)
+
+Note: the add controls are a <div>, NOT a <form>, so this widget can be placed
+inside another form (e.g. the dataset metadata form) without nesting forms.
 {% endcomment %}
 <div class="mt-3" id="credit-contributors" data-contrib-base="{{ contrib_base }}">
   <h6 class="fw-bold mb-1">CRediT Contributors
@@ -13,6 +16,13 @@ Reusable CRediT contributors editor (Phase 2b). Required context:
        data-bs-toggle="tooltip" data-bs-title="Contributor Roles Taxonomy">
       <i class="fas fa-question-circle fa-xs"></i></a>
   </h6>
+  {% if can_edit_credit %}
+  <p class="small text-muted fst-italic mb-1">
+    These structured CRediT contributors are intended to supersede the free-text
+    Creator(s)/Contributor(s) fields. Please check the auto-imported entries below,
+    then clear those deprecated fields once you have verified them.
+  </p>
+  {% endif %}
   <ul class="list-unstyled mb-2" id="contrib-list">
     {% for c in contributions %}
       <li data-cid="{{ c.id }}" class="mb-1">
@@ -26,12 +36,12 @@ Reusable CRediT contributors editor (Phase 2b). Required context:
     {% endfor %}
   </ul>
   {% if can_edit_credit %}
-  <form id="contrib-add-form" class="row g-1 small align-items-center">
-    <div class="col-12 col-md-3"><input type="text" name="name" class="form-control form-control-sm" placeholder="Name or [Organisation]" required></div>
+  <div id="contrib-add-form" class="row g-1 small align-items-center">
+    <div class="col-12 col-md-3"><input type="text" name="name" class="form-control form-control-sm" placeholder="Name or [Organisation]"></div>
     <div class="col-6 col-md-2"><input type="text" name="orcid" class="form-control form-control-sm" placeholder="ORCiD (optional)"></div>
     <div class="col-6 col-md-2"><input type="text" name="affiliation" class="form-control form-control-sm" placeholder="Affiliation"></div>
     <div class="col-6 col-md-2">
-      <select name="role" class="form-select form-select-sm" required>
+      <select name="role" class="form-select form-select-sm">
         <option value="">Role…</option>
         {% for val, label in credit_roles %}<option value="{{ val }}">{{ label }}</option>{% endfor %}
       </select>
@@ -43,9 +53,9 @@ Reusable CRediT contributors editor (Phase 2b). Required context:
       </select>
     </div>
     <div class="col-3 col-md-1"><label class="small mb-0"><input type="checkbox" name="is_corresponding"> corr.</label></div>
-    <div class="col-auto"><button type="submit" class="btn btn-sm btn-primary">Add</button></div>
+    <div class="col-auto"><button type="button" id="contrib-add-btn" class="btn btn-sm btn-primary">Add</button></div>
     <div class="col-12"><span id="contrib-error" class="text-danger small"></span></div>
-  </form>
+  </div>
   {% endif %}
 </div>
 <script>
@@ -57,7 +67,8 @@ Reusable CRediT contributors editor (Phase 2b). Required context:
   var meta = document.querySelector('meta[name="csrf-token"]');
   var csrf = meta ? meta.getAttribute('content') : '';
   var list = document.getElementById('contrib-list');
-  var form = document.getElementById('contrib-add-form');
+  var addEl = document.getElementById('contrib-add-form');
+  var addBtn = document.getElementById('contrib-add-btn');
   var errEl = document.getElementById('contrib-error');
 
   function onDelete(e) {
@@ -73,43 +84,57 @@ Reusable CRediT contributors editor (Phase 2b). Required context:
   }
   bindDelete();
 
-  if (form) {
-    form.addEventListener('submit', function (e) {
-      e.preventDefault();
-      errEl.textContent = '';
-      fetch(base + '/add',
-            {method: 'POST', headers: {'X-CSRFToken': csrf}, body: new FormData(form)})
-        .then(function (r) { return r.json().then(function (d) { return {ok: r.ok, d: d}; }); })
-        .then(function (res) {
-          if (!res.ok) { errEl.textContent = res.d.error || 'Error adding contributor.'; return; }
-          var d = res.d;
-          var empty = document.getElementById('contrib-empty');
-          if (empty) empty.remove();
-          var li = document.createElement('li');
-          li.setAttribute('data-cid', d.id);
-          li.className = 'mb-1';
-          var nameSpan = document.createElement('span');
-          nameSpan.className = 'fw-semibold';
-          nameSpan.textContent = d.person;  // user input -> textContent (no XSS)
-          li.appendChild(nameSpan);
-          if (d.orcid) {
-            li.insertAdjacentHTML('beforeend',
-              ' <a href="https://orcid.org/' + encodeURIComponent(d.orcid) +
-              '" target="_blank" rel="noopener" title="ORCiD"><i class="fab fa-orcid"></i></a>');
-          }
-          li.appendChild(document.createTextNode(
-            ' — ' + d.role + (d.degree ? ' (' + d.degree + ')' : '')));
-          if (d.is_corresponding) {
-            li.insertAdjacentHTML('beforeend',
-              ' <span class="badge bg-light text-dark border">corresponding</span>');
-          }
+  function field(n) { var el = addEl.querySelector('[name="' + n + '"]'); return el ? el.value : ''; }
+
+  function submitAdd() {
+    errEl.textContent = '';
+    var fd = new FormData();
+    ['name', 'orcid', 'affiliation', 'role', 'degree'].forEach(function (n) { fd.append(n, field(n)); });
+    var corr = addEl.querySelector('[name="is_corresponding"]');
+    fd.append('is_corresponding', corr && corr.checked ? 'true' : 'false');
+    fetch(base + '/add', {method: 'POST', headers: {'X-CSRFToken': csrf}, body: fd})
+      .then(function (r) { return r.json().then(function (d) { return {ok: r.ok, d: d}; }); })
+      .then(function (res) {
+        if (!res.ok) { errEl.textContent = res.d.error || 'Error adding contributor.'; return; }
+        var d = res.d;
+        var empty = document.getElementById('contrib-empty');
+        if (empty) empty.remove();
+        var li = document.createElement('li');
+        li.setAttribute('data-cid', d.id);
+        li.className = 'mb-1';
+        var nameSpan = document.createElement('span');  // user input -> textContent (no XSS)
+        nameSpan.className = 'fw-semibold';
+        nameSpan.textContent = d.person;
+        li.appendChild(nameSpan);
+        if (d.orcid) {
           li.insertAdjacentHTML('beforeend',
-            ' <a href="#" class="contrib-del text-danger ms-1" title="Remove"><i class="fas fa-times fa-xs"></i></a>');
-          list.appendChild(li);
-          bindDelete(li);
-          form.reset();
-        })
-        .catch(function () { errEl.textContent = 'Network error.'; });
+            ' <a href="https://orcid.org/' + encodeURIComponent(d.orcid) +
+            '" target="_blank" rel="noopener" title="ORCiD"><i class="fab fa-orcid"></i></a>');
+        }
+        li.appendChild(document.createTextNode(
+          ' — ' + d.role + (d.degree ? ' (' + d.degree + ')' : '')));
+        if (d.is_corresponding) {
+          li.insertAdjacentHTML('beforeend',
+            ' <span class="badge bg-light text-dark border">corresponding</span>');
+        }
+        li.insertAdjacentHTML('beforeend',
+          ' <a href="#" class="contrib-del text-danger ms-1" title="Remove"><i class="fas fa-times fa-xs"></i></a>');
+        list.appendChild(li);
+        bindDelete(li);
+        addEl.querySelectorAll('input').forEach(function (i) {
+          if (i.type === 'checkbox') i.checked = false; else i.value = '';
+        });
+        addEl.querySelectorAll('select').forEach(function (s) { s.value = ''; });
+      })
+      .catch(function () { errEl.textContent = 'Network error.'; });
+  }
+
+  if (addBtn) {
+    addBtn.addEventListener('click', submitAdd);
+    addEl.querySelectorAll('input').forEach(function (i) {
+      i.addEventListener('keydown', function (e) {
+        if (e.key === 'Enter') { e.preventDefault(); submitAdd(); }
+      });
     });
   }
 })();


### PR DESCRIPTION
Addresses three issues reported on the live dataset metadata page (https://whgazetteer.org/datasets/1593/metadata):

## 1 + 3 — left column placement *and* footer overlap (same root cause)
`builders-dataset.css` sets `.container { max-height: calc(100vh - 110px) }` and gives **only** the left column (`#ds_details`) `overflow-y:auto`. The widget was in the right column (`#ds_info`), which doesn't scroll — so its height overflowed the container and rendered over/below the footer. **Moving the widget into the left column `#ds_details`** (which scrolls internally) fixes the footer overlap *and* places it beside the Creator(s)/Contributors fields it supersedes. No CSS-bundle rebuild needed.

## Nested-form fix (enabling the left-column move)
The dataset metadata `#ds_form` wraps both columns, so the widget's `<form>` was nested inside it (invalid HTML). The add controls are now a **`<div>`** (submission via the existing `fetch` JS, triggered by the Add button + Enter key), so the widget can live inside `#ds_form` without nesting forms.

## 2 — editor note about the deprecated free-text fields
Adds an editor-only note: *"These structured CRediT contributors are intended to supersede the free-text Creator(s)/Contributor(s) fields. Please check the auto-imported entries below, then clear those deprecated fields once you have verified them."* (Shown on datasets and collections via the shared include.)

## Validation
All 4 affected templates parse clean; dataset + collection contribution endpoint tests pass (6/6). No model/migration/Python change — templates only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
