### PR TITLE
feat(api): namespace-aggregated attribution endpoint + helper (Phase 3)

### DIFF
--- a/api/attribution.py
+++ b/api/attribution.py
@@ -1,0 +1,51 @@
+"""Namespace-aggregated gazetteer attribution (citations design §4.7).
+
+Surfaces, per namespace present in a result set, the attribution recorded in
+the gazetteer registry, plus WHG's own curation/aggregation licence overlay.
+Uses the registry fields available today (name, description-as-citation,
+record_count); structured licence/rights_holder fields arrive with the
+authorities source-of-truth phase and will slot into the same shape.
+"""
+from django.conf import settings
+
+from api.models import GazetteerRegistryEntry
+from api.reconcile_helpers import get_namespace
+
+
+def attribution_for(namespaces):
+    """Return {namespace: {name, citation, record_count}} for the given
+    namespace codes, drawn from the registry's ``authority`` rows.
+
+    Unknown namespaces (and non-authority namespaces such as per-dataset
+    ``whg`` sub-namespaces, which are covered by the WHG overlay) are omitted.
+    """
+    codes = {n.strip().lower() for n in namespaces if n and str(n).strip()}
+    if not codes:
+        return {}
+    out = {}
+    for entry in GazetteerRegistryEntry.objects.filter(
+            namespace__in=codes, entry_class='authority'):
+        out[entry.namespace] = {
+            'name': entry.name,
+            'citation': entry.description or '',
+            'record_count': entry.record_count,
+        }
+    return out
+
+
+def attribution_block(namespaces):
+    """Full attribution envelope: per-source attribution + the WHG overlay.
+
+    The WHG overlay (settings.WHG_OVERLAY_LICENSE) is WHG's own
+    curation/aggregation licence, asserted *alongside* each source's rights.
+    """
+    return {
+        'sources': attribution_for(namespaces),
+        'whg': getattr(settings, 'WHG_OVERLAY_LICENSE', None),
+    }
+
+
+def namespaces_from_ids(ids):
+    """Derive the set of namespace codes present in a list of place ids
+    (e.g. ``"gn:745044"`` -> ``"gn"``)."""
+    return {get_namespace(str(i)) for i in ids if i}

--- a/api/tests_attribution.py
+++ b/api/tests_attribution.py
@@ -1,0 +1,45 @@
+from django.test import TestCase
+
+from api.attribution import attribution_for, attribution_block, namespaces_from_ids
+
+
+class AttributionHelperTests(TestCase):
+    """gn/wd/tgn etc. are seeded as authority rows by api migration 0003."""
+
+    def test_namespaces_from_ids(self):
+        self.assertEqual(
+            namespaces_from_ids(['gn:745044', 'wd:Q84', '']), {'gn', 'wd'})
+
+    def test_attribution_for_seeded_authorities(self):
+        attr = attribution_for(['gn', 'wd'])
+        self.assertIn('gn', attr)
+        self.assertIn('wd', attr)
+        self.assertIn('name', attr['gn'])
+        self.assertIn('citation', attr['gn'])
+
+    def test_unknown_namespace_omitted(self):
+        self.assertNotIn('zz', attribution_for(['zz']))
+
+    def test_block_has_whg_overlay(self):
+        block = attribution_block(['gn'])
+        self.assertIn('sources', block)
+        self.assertEqual(block['whg']['spdx_id'], 'CC-BY-NC-4.0')
+
+
+class AttributionEndpointTests(TestCase):
+    def test_namespaces_param(self):
+        r = self.client.get('/api/attribution/?namespaces=gn,wd')
+        self.assertEqual(r.status_code, 200)
+        data = r.json()
+        self.assertIn('gn', data['sources'])
+        self.assertIsNotNone(data['whg'])
+
+    def test_ids_param(self):
+        r = self.client.get('/api/attribution/?ids=gn:745044')
+        self.assertEqual(r.status_code, 200)
+        self.assertIn('gn', r.json()['sources'])
+
+    def test_empty(self):
+        r = self.client.get('/api/attribution/')
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json()['sources'], {})

--- a/api/urls.py
+++ b/api/urls.py
@@ -9,6 +9,8 @@ from . import views
 # naming this app BREAKS DATATABLES IN DATASET BROWSE
 
 urlpatterns = [
+    # gazetteer attribution for a set of namespaces / place ids (citations §4.7)
+    path('attribution/', views.AttributionView.as_view(), name='api-attribution'),
     # database places to be DEPRECATED
     path('db/', views.SearchAPIView.as_view(), name='api-search'),
     # index docs

--- a/api/views.py
+++ b/api/views.py
@@ -1680,3 +1680,30 @@ class WatershedAPIView(APIView):
             raise Http404(f"Error fetching watershed GeoJSON: {str(e)}")
 
         return Response(watershed_geojson)
+
+
+class AttributionView(APIView):
+    """Resolve gazetteer attribution for the namespaces present in a result set
+    (citations design §4.7). Public registry metadata — no token required.
+
+    GET /api/attribution/?namespaces=gn,wd,tgn
+    GET /api/attribution/?ids=gn:745044,wd:Q84
+
+    Returns ``{"sources": {ns: {name, citation, record_count}}, "whg": {…overlay…}}``.
+    Consumers of the reconciliation / search / extension APIs can resolve the
+    attribution for the namespaces appearing in their results.
+    """
+    authentication_classes = []
+    permission_classes = [permissions.AllowAny]
+
+    def get(self, request):
+        from api.attribution import attribution_block, namespaces_from_ids
+        namespaces = set()
+        ns_param = request.GET.get('namespaces')
+        if ns_param:
+            namespaces |= {n.strip().lower() for n in ns_param.split(',') if n.strip()}
+        ids_param = request.GET.get('ids')
+        if ids_param:
+            namespaces |= namespaces_from_ids(
+                [i.strip() for i in ids_param.split(',') if i.strip()])
+        return Response(attribution_block(namespaces))


### PR DESCRIPTION
Phase 3 — surface gazetteer **attribution by namespace** through the API (citations design §4.7).

## What it adds
- **`api.attribution`** — `attribution_for(namespaces)` returns `{ns: {name, citation, record_count}}` from the gazetteer registry's `authority` rows; `attribution_block(namespaces)` wraps that as `{sources, whg}` where `whg` is the WHG curation/aggregation overlay (`settings.WHG_OVERLAY_LICENSE`), asserted *alongside* source rights; `namespaces_from_ids` derives namespaces from place ids (`gn:745044` → `gn`).
- **`GET /api/attribution/`** (public — registry metadata, no token):
  - `?namespaces=gn,wd,tgn` or `?ids=gn:745044,wd:Q84` → `{"sources": {...}, "whg": {…overlay…}}`.
  - Lets consumers of the reconciliation / search / extension APIs resolve attribution for the namespaces appearing in their results.

## Why a companion endpoint (not in-response embedding)
The reconciliation response is keyed by query-id (no clean envelope for a top-level block), and search/extension flow through the CRC gateway. A dedicated, additive endpoint surfaces the same namespace-aggregated attribution without modifying (or risking) the standardized/complex response builders. Embedding into specific responses can follow once the structured licence fields land.

## Safety / scope
- **No model or migration change** (api is at `0004` on main vs `0006` on atlas — deliberately avoided an api migration). Uses the registry fields available today (`name`, `description`-as-citation, `record_count`). The **structured `license`/`rights_holder`/`citation_text` fields arrive with Phase 4 (authorities SoT)** and slot into the same `attribution_for` shape.
- Public endpoint, read-only.

## Validation
`manage.py test api.tests_attribution` → **7/7 OK** (helper over seeded authorities, unknown omitted, WHG overlay; endpoint via `?namespaces`/`?ids`/empty). `manage.py check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
