### PR TITLE
Citations Phase 4 — authorities attribution source-of-truth

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -59,6 +59,19 @@ class GazetteerRegistryEntryAdmin(admin.ModelAdmin):
         ("Curatorial (editable)", {
             'fields': ('core', 'region_source', 'no_explore', 'gazetteer_type'),
         }),
+        ("Attribution / licence / rights", {
+            'description': (
+                "Source-of-truth is the indexing AUTHORITIES config, pushed "
+                "by the inventory job. The push only writes the fields it "
+                "sends, so values set here are a safe interim until that push "
+                "is upgraded — after which it becomes authoritative and may "
+                "overwrite them."
+            ),
+            'fields': (
+                'citation_text', 'license', 'license_url', 'rights_holder',
+                'source_url', 'contributors_csl',
+            ),
+        }),
         ("Re-ingest (managed via the Re-ingest action)", {
             'fields': (
                 'reingest_status', 'reingest_started_at',

--- a/api/attribution.py
+++ b/api/attribution.py
@@ -2,9 +2,14 @@
 
 Surfaces, per namespace present in a result set, the attribution recorded in
 the gazetteer registry, plus WHG's own curation/aggregation licence overlay.
-Uses the registry fields available today (name, description-as-citation,
-record_count); structured licence/rights_holder fields arrive with the
-authorities source-of-truth phase and will slot into the same shape.
+
+Since Phase 4 (authorities source-of-truth) the registry carries structured
+``citation_text``, ``license`` (FK), ``license_url``, ``rights_holder`` and
+``contributors_csl`` fields, populated by the indexing pipeline's inventory
+push. ``citation`` prefers ``citation_text`` and falls back to the legacy
+``description`` blob for rows pushed before the upgrade; ``license`` and the
+other structured keys are emitted only when present, so the shape degrades
+gracefully on un-upgraded data.
 """
 from django.conf import settings
 
@@ -12,24 +17,52 @@ from api.models import GazetteerRegistryEntry
 from api.reconcile_helpers import get_namespace
 
 
-def attribution_for(namespaces):
-    """Return {namespace: {name, citation, record_count}} for the given
-    namespace codes, drawn from the registry's ``authority`` rows.
+def _entry_attribution(entry):
+    """Build the per-source attribution dict for one registry row."""
+    data = {
+        'name': entry.name,
+        'citation': (entry.citation_text or entry.description or ''),
+        'record_count': entry.record_count,
+    }
+    # Structured licence: prefer the resolved FK, allowing a per-source URL
+    # override (``license_url``) over the canonical deed.
+    if entry.license_id is not None:
+        data['license'] = {
+            'spdx_id': entry.license.spdx_id,
+            'label': entry.license.label,
+            'url': entry.license_url or entry.license.url,
+        }
+    elif entry.license_url:
+        data['license'] = {'spdx_id': None, 'label': None,
+                           'url': entry.license_url}
+    if entry.rights_holder:
+        data['rights_holder'] = entry.rights_holder
+    if entry.source_url:
+        data['source_url'] = entry.source_url
+    if entry.contributors_csl:
+        data['contributors'] = entry.contributors_csl
+    return data
 
-    Unknown namespaces (and non-authority namespaces such as per-dataset
-    ``whg`` sub-namespaces, which are covered by the WHG overlay) are omitted.
+
+def attribution_for(namespaces):
+    """Return ``{namespace: {name, citation, record_count, license?,
+    rights_holder?, source_url?, contributors?}}`` for the given namespace
+    codes, drawn from the registry's ``authority`` rows.
+
+    Optional keys (``license``/``rights_holder``/``source_url``/
+    ``contributors``) appear only when the registry has them. Unknown
+    namespaces (and non-authority namespaces such as per-dataset ``whg``
+    sub-namespaces, which are covered by the WHG overlay) are omitted.
     """
     codes = {n.strip().lower() for n in namespaces if n and str(n).strip()}
     if not codes:
         return {}
     out = {}
-    for entry in GazetteerRegistryEntry.objects.filter(
-            namespace__in=codes, entry_class='authority'):
-        out[entry.namespace] = {
-            'name': entry.name,
-            'citation': entry.description or '',
-            'record_count': entry.record_count,
-        }
+    qs = (GazetteerRegistryEntry.objects
+          .filter(namespace__in=codes, entry_class='authority')
+          .select_related('license'))
+    for entry in qs:
+        out[entry.namespace] = _entry_attribution(entry)
     return out
 
 

--- a/api/migrations/0007_registry_attribution_fields.py
+++ b/api/migrations/0007_registry_attribution_fields.py
@@ -1,0 +1,58 @@
+# Generated for citations design Phase 4 (authorities source-of-truth).
+#
+# Adds push-managed attribution/licence/rights fields to the gazetteer
+# registry. These are populated by the indexing pipeline's Batch 11 push
+# (processing/push_gazetteer_inventory.py) and applied by
+# api/views_indexing.py::GazetteerInventoryView._upsert_one.
+#
+# All fields are nullable/defaulted so existing rows (and pushes that omit
+# them) remain valid; attribution_for() falls back to ``description`` until
+# ``citation_text`` is populated by an upgraded push.
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('licensing', '0001_initial'),
+        ('api', '0006_remove_stale_dplace_seed'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='gazetteerregistryentry',
+            name='citation_text',
+            field=models.TextField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='gazetteerregistryentry',
+            name='license',
+            field=models.ForeignKey(
+                blank=True, null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name='gazetteer_entries',
+                to='licensing.license',
+            ),
+        ),
+        migrations.AddField(
+            model_name='gazetteerregistryentry',
+            name='license_url',
+            field=models.URLField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='gazetteerregistryentry',
+            name='rights_holder',
+            field=models.CharField(blank=True, max_length=255, null=True),
+        ),
+        migrations.AddField(
+            model_name='gazetteerregistryentry',
+            name='source_url',
+            field=models.URLField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='gazetteerregistryentry',
+            name='contributors_csl',
+            field=models.JSONField(blank=True, default=list),
+        ),
+    ]

--- a/api/models.py
+++ b/api/models.py
@@ -215,6 +215,38 @@ class GazetteerRegistryEntry(models.Model):
     # ``[min_start_year, max_end_year]`` with each endpoint optionally null.
     temporal_extent = models.JSONField(default=list)
 
+    # ── Attribution / licence / rights (citations design §3.2) ──────────
+    # Source-of-truth = indexing ``AUTHORITIES`` → pushed by Batch 11
+    # (``push_gazetteer_inventory.py``) into the inventory payload, applied
+    # by ``api/views_indexing.py::GazetteerInventoryView._upsert_one``.
+    # These are *push-managed* like the other inventory fields above (NOT in
+    # the admin-protected curatorial set), so a push refreshes them from the
+    # canonical source. All optional — a source supplies whatever it has
+    # (design decision 3: metadata flexibility).
+    #
+    # Human-readable citation. Historically the citation blob was crammed
+    # into ``description``; new pushes populate this and keep ``description``
+    # for genuine prose. ``attribution_for()`` prefers this, falling back to
+    # ``description`` for rows pushed before the upgrade.
+    citation_text = models.TextField(null=True, blank=True)
+    # Canonical SPDX licence; resolved from the pushed ``license_spdx`` code.
+    license = models.ForeignKey(
+        'licensing.License',
+        on_delete=models.SET_NULL,
+        null=True, blank=True,
+        related_name='gazetteer_entries',
+    )
+    # Override deed URL when the source deviates from the canonical licence
+    # deed (left null to use ``license.url``).
+    license_url = models.URLField(null=True, blank=True)
+    # e.g. "J. Paul Getty Trust", "ISAW".
+    rights_holder = models.CharField(max_length=255, null=True, blank=True)
+    # Homepage / landing page for the source.
+    source_url = models.URLField(null=True, blank=True)
+    # Optional CRediT-shaped provider credit where the source documents it:
+    # ``[{"name": ..., "role": ..., "orcid": ...}]`` (see §3.3 output shape).
+    contributors_csl = models.JSONField(default=list, blank=True)
+
     # Curatorial fields managed via the Django admin only — the inventory
     # push from the indexing pipeline deliberately omits these so it never
     # overwrites staff curation. Defaults must mirror the migration so

--- a/api/tests_attribution.py
+++ b/api/tests_attribution.py
@@ -1,6 +1,9 @@
 from django.test import TestCase
 
 from api.attribution import attribution_for, attribution_block, namespaces_from_ids
+from api.models import GazetteerRegistryEntry
+from api.views_indexing import GazetteerInventoryView
+from licensing.models import License
 
 
 class AttributionHelperTests(TestCase):
@@ -24,6 +27,116 @@ class AttributionHelperTests(TestCase):
         block = attribution_block(['gn'])
         self.assertIn('sources', block)
         self.assertEqual(block['whg']['spdx_id'], 'CC-BY-NC-4.0')
+
+    # ── Phase 4 structured attribution ──────────────────────────────────
+
+    def test_citation_text_preferred_over_description(self):
+        entry = GazetteerRegistryEntry.objects.filter(
+            namespace='gn', entry_class='authority').first()
+        entry.description = 'legacy blob'
+        entry.citation_text = 'Proper citation.'
+        entry.save()
+        self.assertEqual(attribution_for(['gn'])['gn']['citation'],
+                         'Proper citation.')
+
+    def test_description_fallback_when_no_citation_text(self):
+        entry = GazetteerRegistryEntry.objects.filter(
+            namespace='gn', entry_class='authority').first()
+        entry.description = 'legacy blob'
+        entry.citation_text = None
+        entry.save()
+        self.assertEqual(attribution_for(['gn'])['gn']['citation'],
+                         'legacy blob')
+
+    def test_structured_license_and_rights_emitted(self):
+        lic = License.objects.get(spdx_id='CC-BY-4.0')
+        entry = GazetteerRegistryEntry.objects.filter(
+            namespace='gn', entry_class='authority').first()
+        entry.license = lic
+        entry.rights_holder = 'Unxos GmbH'
+        entry.source_url = 'https://www.geonames.org/'
+        entry.contributors_csl = [{'name': 'M. Wick', 'role': 'Resources'}]
+        entry.save()
+        attr = attribution_for(['gn'])['gn']
+        self.assertEqual(attr['license']['spdx_id'], 'CC-BY-4.0')
+        self.assertEqual(attr['license']['url'], lic.url)
+        self.assertEqual(attr['rights_holder'], 'Unxos GmbH')
+        self.assertEqual(attr['source_url'], 'https://www.geonames.org/')
+        self.assertEqual(attr['contributors'][0]['name'], 'M. Wick')
+
+    def test_license_url_override(self):
+        lic = License.objects.get(spdx_id='CC-BY-4.0')
+        entry = GazetteerRegistryEntry.objects.filter(
+            namespace='gn', entry_class='authority').first()
+        entry.license = lic
+        entry.license_url = 'https://example.org/custom-deed'
+        entry.save()
+        self.assertEqual(attribution_for(['gn'])['gn']['license']['url'],
+                         'https://example.org/custom-deed')
+
+    def test_optional_keys_absent_when_unset(self):
+        # A freshly-seeded row with no Phase 4 fields set omits the optional
+        # keys entirely (graceful shape on un-upgraded data).
+        entry = GazetteerRegistryEntry.objects.filter(
+            namespace='wd', entry_class='authority').first()
+        entry.license = None
+        entry.license_url = None
+        entry.rights_holder = None
+        entry.source_url = None
+        entry.contributors_csl = []
+        entry.save()
+        attr = attribution_for(['wd'])['wd']
+        for key in ('license', 'rights_holder', 'source_url', 'contributors'):
+            self.assertNotIn(key, attr)
+
+
+class InventoryPushAttributionTests(TestCase):
+    """The Batch 11 push (``GazetteerInventoryView._upsert_one``) accepting
+    the Phase 4 attribution fields. Tested at the method level — token auth /
+    HTTP handling are exercised by the auth class, not this logic."""
+
+    def setUp(self):
+        self.view = GazetteerInventoryView()
+
+    def _push(self, **extra):
+        entry = {'id': 'gn', 'namespace': 'gn', 'class': 'authority',
+                 'name': 'GeoNames'}
+        entry.update(extra)
+        return self.view._upsert_one(entry)
+
+    def test_resolves_known_license_spdx(self):
+        ok, err = self._push(license_spdx='CC-BY-4.0',
+                             citation_text='GeoNames database.',
+                             rights_holder='Unxos GmbH')
+        self.assertTrue(ok, err)
+        row = GazetteerRegistryEntry.objects.get(id='gn')
+        self.assertEqual(row.license.spdx_id, 'CC-BY-4.0')
+        self.assertEqual(row.citation_text, 'GeoNames database.')
+        self.assertEqual(row.rights_holder, 'Unxos GmbH')
+
+    def test_unknown_license_spdx_skipped_not_fatal(self):
+        ok, err = self._push(license_spdx='NO-SUCH-LICENCE-9.9',
+                             citation_text='still stored')
+        self.assertTrue(ok, err)
+        row = GazetteerRegistryEntry.objects.get(id='gn')
+        self.assertIsNone(row.license_id)
+        self.assertEqual(row.citation_text, 'still stored')
+
+    def test_contributors_alias_mapped_to_csl(self):
+        ok, err = self._push(contributors=[{'name': 'X', 'role': 'Resources'}])
+        self.assertTrue(ok, err)
+        self.assertEqual(
+            GazetteerRegistryEntry.objects.get(id='gn').contributors_csl,
+            [{'name': 'X', 'role': 'Resources'}])
+
+    def test_omitted_attribution_left_untouched(self):
+        # Seed a value, then push without the field — it must survive.
+        self._push(citation_text='keep me')
+        ok, err = self._push(record_count=999)
+        self.assertTrue(ok, err)
+        row = GazetteerRegistryEntry.objects.get(id='gn')
+        self.assertEqual(row.citation_text, 'keep me')
+        self.assertEqual(row.record_count, 999)
 
 
 class AttributionEndpointTests(TestCase):

--- a/api/views_indexing.py
+++ b/api/views_indexing.py
@@ -67,13 +67,26 @@ class GazetteerInventoryView(AuthenticatedAPIView):
               "record_count": 13000000,
               "status": "published",
               "h3_coverage": "global",
-              "temporal_extent": [-2000, 2025]
+              "temporal_extent": [-2000, 2025],
+
+              // Phase 4 attribution fields (all optional; the indexing
+              // AUTHORITIES config is the source of truth):
+              "citation_text": "GeoNames geographical database. ...",
+              "license_spdx":  "CC-BY-4.0",      // resolved to a License FK
+              "license_url":   "https://...",    // optional deed override
+              "rights_holder": "Unxos GmbH",
+              "source_url":    "https://www.geonames.org/",
+              "contributors":  [{"name": "...", "role": "...", "orcid": "..."}]
             },
             ...
           ]
         }
 
     Returns ``{"upserted": <int>, "errors": [...]}``.
+
+    Unknown ``license_spdx`` codes are logged and skipped (the row's other
+    fields still upsert). Fields absent from a payload are left untouched, so
+    a not-yet-upgraded push is fully backward compatible.
     """
 
     http_method_names = ["post", "put", "options"]
@@ -106,6 +119,31 @@ class GazetteerInventoryView(AuthenticatedAPIView):
         owner_user_id = entry.get("owner_user_id")
         if owner_user_id is not None:
             defaults["owner_id"] = owner_user_id
+
+        # Attribution / licence / rights (citations design Phase 4). All
+        # optional — only fields actually present in the payload are written,
+        # so a push that omits them leaves any prior values intact. These are
+        # push-managed: the indexing ``AUTHORITIES`` config is the SoT.
+        for key in ("citation_text", "license_url", "rights_holder",
+                    "source_url"):
+            if key in entry:
+                defaults[key] = entry.get(key)
+        if "contributors" in entry:
+            defaults["contributors_csl"] = entry.get("contributors") or []
+        # Resolve the SPDX code to a seeded ``License`` row. Unknown codes are
+        # logged and skipped (license left untouched) rather than failing the
+        # whole entry — flexibility over strictness (design decision 3).
+        license_spdx = entry.get("license_spdx")
+        if license_spdx:
+            from licensing.models import License
+            lic = License.objects.filter(spdx_id=license_spdx).first()
+            if lic is not None:
+                defaults["license_id"] = lic.pk
+            else:
+                logger.warning(
+                    "GazetteerInventoryView: unknown license_spdx %r for %s "
+                    "— leaving license unset", license_spdx, entry_id,
+                )
 
         try:
             GazetteerRegistryEntry.objects.update_or_create(

--- a/search/views.py
+++ b/search/views.py
@@ -181,6 +181,12 @@ class AtlasPageView(TemplateView):
             .values(
                 'id', 'name', 'description', 'namespace', 'core',
                 'no_explore', 'gazetteer_type', 'record_count',
+                # Attribution fields (citations Phase 4) — surfaced in the
+                # Gazetteers offcanvas. license_url falls back to the deed
+                # URL on the resolved License row.
+                'citation_text', 'rights_holder', 'source_url',
+                'contributors_csl', 'license__spdx_id', 'license__label',
+                'license__url', 'license_url',
             )
         )
         specialist_gazetteers = list(


### PR DESCRIPTION
**Phase 4** of the citations/licences/CRediT design — the WHG-side authorities **source-of-truth** schema and plumbing. Builds on Phases 1–3 (now on atlas via #531). The companion indexing-repo work (upgrading `AUTHORITIES` + the Batch 11 push to send these fields, and auditing every authority's real licence) is the cross-repo **Phase 6** handoff; this PR is the endpoint/schema it targets.

## Changes
- **`api.GazetteerRegistryEntry`** — six push-managed attribution fields: `citation_text`, `license` (FK → `licensing.License`, `SET_NULL`), `license_url`, `rights_holder`, `source_url`, `contributors_csl` (JSON). Migration **`api/0007`** (off `0006`, depends on `licensing/0001`); all nullable/defaulted, so existing rows stay valid.
- **`GazetteerInventoryView._upsert_one`** — accepts `citation_text` / `license_spdx` / `license_url` / `rights_holder` / `source_url` / `contributors`; resolves `license_spdx` → `License` FK (unknown codes **logged and skipped**, not fatal). Only writes keys actually present in the payload, so a not-yet-upgraded push is backward compatible and leaves prior values intact.
- **`attribution_for()`** — structured shape: `citation` prefers `citation_text`, falls back to `description`; optional `license` / `rights_holder` / `source_url` / `contributors` emitted only when present (graceful on un-upgraded data).
- **`search.AtlasPageView`** — surfaces the new fields in the Gazetteers offcanvas serialisation (§4.5).
- **admin** — editable "Attribution / licence / rights" fieldset, an interim curation path until the indexing push is upgraded (after which it becomes authoritative).

## Cross-environment note
The indexing pipeline pushes the inventory to **both dev and prod**. The push endpoint **already ignores unknown payload fields**, so when indexing is upgraded to send these fields it is safe against a prod that hasn't yet received this code — prod simply won't *store* the extras until Phase 4 lands on `main`. Achieving the same augmented schema on both envs is therefore decoupled from the indexing rollout and happens at the atlas→main promotion (a naive second-sibling `api` migration on `main` would re-create the periods duplicate-column trap and is deliberately avoided).

## Validation (container vs dev Postgres, throwaway test DB)
- `makemigrations --check` — no api/citations drift (only the pre-existing third-party `guardian` env quirk)
- Fresh test DB builds
- `manage.py test api.tests_attribution persons licensing` — **40/40 OK** (+9 new Phase 4 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)