### PR TITLE
Citations Phase 5a — truthful per-object licence (DOI / downloads / exports)

### DIFF
--- a/api/download_file.py
+++ b/api/download_file.py
@@ -225,13 +225,10 @@ def stream_live(obj_type, obj, request, filetype='lpf', cache_filepath=None):
                 else:
                     yield from emit_chunk(',"citation":' + json.dumps(citation))
 
-            licence_text = (
-                "Unless specified otherwise, all content created for or uploaded to the World Historical Gazetteer — "
-                "including editorial content, documentation, images, and contributed datasets and collections — "
-                "is licensed under a Creative Commons Attribution-NonCommercial 4.0 International License. "
-                "Externally hosted datasets and content that are linked to by WHG remain under the copyrights "
-                "and licenses specified by their original contributors."
-            )
+            # Truthful per-object licence: the source licence (when recorded)
+            # plus WHG's aggregation overlay. See licensing/rights.py (§4.3).
+            from licensing.rights import rights_statement_text
+            licence_text = rights_statement_text(obj)
             yield from emit_chunk(',"license":' + json.dumps(licence_text))
             yield from emit_chunk(',"features":[')
 

--- a/licensing/rights.py
+++ b/licensing/rights.py
@@ -1,0 +1,95 @@
+"""Truthful, per-object rights/licence rendering (citations design §4.2–4.3).
+
+Replaces the sitewide hard-coded CC-BY-NC-4.0 assertion. A WHG object's rights
+are the *source* licence chosen by the contributor (``obj.license`` — a
+``License`` row, optional) asserted **alongside** WHG's own aggregation/curation
+overlay (``settings.WHG_OVERLAY_LICENSE``), never instead of it (design
+decisions 1+2). Where no source licence is recorded we assert only the WHG
+overlay — we never fabricate a source licence (which is exactly the bug this
+replaces: stamping ``-NC`` over ODbL / ODC-By / public-domain source data).
+
+One code path feeds DataCite DOI metadata (``utils/doi.py``), download
+envelopes (``api/download_file.py``), and export READMEs (``utils/tasks.py``).
+"""
+from django.conf import settings
+
+
+def _overlay():
+    """WHG's aggregation/curation overlay licence, or None if unset."""
+    return getattr(settings, 'WHG_OVERLAY_LICENSE', None)
+
+
+def _license_of(obj):
+    """Return the object's source ``License`` instance, or None.
+
+    Tolerant of objects without the FK (e.g. place-type DOIs) and of the
+    ``Link.license`` CharField (ignored here — it's not a ``License`` row).
+    """
+    lic = getattr(obj, 'license', None)
+    # Only treat it as a source licence if it looks like a License row
+    # (has an spdx_id) — guards against the legacy CharField on other models.
+    return lic if getattr(lic, 'spdx_id', None) else None
+
+
+def datacite_rights_list(obj):
+    """Build a DataCite ``rightsList`` for ``obj``.
+
+    Always includes the WHG overlay; prepends the object's own source licence
+    when one is recorded. Returns a list of DataCite rights dicts.
+    """
+    out = []
+    lic = _license_of(obj)
+    if lic is not None:
+        out.append({
+            'rights': lic.label,
+            'rightsURI': lic.url or '',
+            'rightsIdentifier': lic.spdx_id,
+            'rightsIdentifierScheme': 'SPDX',
+            'schemeURI': lic.spdx_uri or 'https://spdx.org/licenses/',
+            'lang': 'en',
+        })
+    overlay = _overlay()
+    if overlay:
+        out.append({
+            'rights': overlay.get('label'),
+            'rightsURI': overlay.get('url') or '',
+            'rightsIdentifier': overlay.get('spdx_id'),
+            'rightsIdentifierScheme': 'SPDX',
+            'schemeURI': 'https://spdx.org/licenses/',
+            'lang': 'en',
+        })
+    return out
+
+
+def rights_statement_text(obj):
+    """Human-readable licence statement for download/export envelopes.
+
+    Names the object's source licence (when recorded), includes any free-text
+    ``rights_statement`` on the object, and always states the WHG overlay.
+    """
+    lic = _license_of(obj)
+    rights_stmt = (getattr(obj, 'rights_statement', '') or '').strip()
+    overlay = _overlay() or {}
+    noun = obj.__class__.__name__.lower()
+    parts = []
+    if lic is not None:
+        suffix = f": {lic.url}" if lic.url else ""
+        parts.append(
+            f"This {noun} is licensed under {lic.label} "
+            f"({lic.spdx_id}){suffix}."
+        )
+    if rights_stmt:
+        parts.append(rights_stmt)
+    if overlay:
+        overlay_url = overlay.get('url') or ''
+        parts.append(
+            "Unless specified otherwise, content created for or uploaded to "
+            "the World Historical Gazetteer is made available under WHG's "
+            f"aggregation licence, {overlay.get('label')} "
+            f"({overlay.get('spdx_id')})"
+            + (f": {overlay_url}" if overlay_url else "") + ". "
+            "Externally hosted datasets and content linked to by WHG remain "
+            "under the copyrights and licences specified by their original "
+            "contributors."
+        )
+    return "\n\n".join(parts)

--- a/licensing/tests.py
+++ b/licensing/tests.py
@@ -2,6 +2,19 @@ from django.template import Context, Template
 from django.test import TestCase
 
 from .models import License
+from .rights import datacite_rights_list, rights_statement_text
+
+
+class _Obj:
+    """Lightweight stand-in for a Dataset/Collection (avoids the real models'
+    save signals, which call DataCite). Only the attrs the helper reads."""
+    def __init__(self, license=None, rights_statement=""):
+        self.license = license
+        self.rights_statement = rights_statement
+
+
+class Dataset(_Obj):
+    pass
 
 
 class LicenseSeedTests(TestCase):
@@ -41,3 +54,39 @@ class LicenseBadgeTests(TestCase):
 
     def test_renders_nothing_without_license(self):
         self.assertEqual(self._render(license=None), "")
+
+
+class RightsHelperTests(TestCase):
+    """licensing.rights — truthful per-object rights (citations §4.2–4.3).
+    The WHG overlay (settings.WHG_OVERLAY_LICENSE) is CC-BY-NC-4.0."""
+
+    def test_datacite_source_then_overlay(self):
+        lic = License.objects.get(spdx_id="ODbL-1.0")
+        rl = datacite_rights_list(Dataset(license=lic))
+        self.assertEqual(len(rl), 2)
+        self.assertEqual(rl[0]["rightsIdentifier"], "ODbL-1.0")   # source first
+        self.assertEqual(rl[1]["rightsIdentifier"], "CC-BY-NC-4.0")  # overlay
+
+    def test_datacite_overlay_only_without_license(self):
+        rl = datacite_rights_list(Dataset(license=None))
+        self.assertEqual([r["rightsIdentifier"] for r in rl], ["CC-BY-NC-4.0"])
+
+    def test_datacite_ignores_non_license_attr(self):
+        # A plain string (e.g. the legacy Link.license CharField) is not a
+        # License row and must not be emitted as a source licence.
+        rl = datacite_rights_list(Dataset(license="some-string"))
+        self.assertEqual([r["rightsIdentifier"] for r in rl], ["CC-BY-NC-4.0"])
+
+    def test_statement_names_source_and_overlay(self):
+        lic = License.objects.get(spdx_id="ODbL-1.0")
+        txt = rights_statement_text(Dataset(license=lic,
+                                           rights_statement="Extra terms."))
+        self.assertIn("ODbL-1.0", txt)
+        self.assertIn("Extra terms.", txt)
+        self.assertIn("CC-BY-NC-4.0", txt)        # overlay still stated
+        self.assertNotIn("noncommercial purposes only", txt)  # no false claim
+
+    def test_statement_overlay_only_without_license(self):
+        txt = rights_statement_text(Dataset(license=None))
+        self.assertNotIn("licensed under", txt)   # no source-licence sentence
+        self.assertIn("aggregation licence", txt)

--- a/utils/doi.py
+++ b/utils/doi.py
@@ -7,6 +7,7 @@ import logging
 from collection.models import Collection
 from datasets.models import Dataset
 from resources.models import Resource
+from licensing.rights import datacite_rights_list
 
 # Set up logger
 logger = logging.getLogger('django')  # Or another logger name from your configuration
@@ -234,16 +235,10 @@ def get_doi_metadata(type, id):
                 "schemeURI": "http://id.loc.gov/authorities/subjects"
             }
         ],
-        "rightsList": [
-            {
-                "rights": "Creative Commons Attribution-NonCommercial 4.0 International",
-                "rightsURI": "https://creativecommons.org/licenses/by-nc/4.0/",
-                "rightsIdentifier": "CC-BY-NC-4.0",
-                "rightsIdentifierScheme": "SPDX",
-                "schemeURI": "https://spdx.org/licenses/",
-                "lang": "en"
-            }
-        ]
+        # Truthful per-object rights: the source licence (when recorded) plus
+        # WHG's aggregation overlay — never a single hard-coded constant.
+        # See licensing/rights.py (citations design §4.2).
+        "rightsList": datacite_rights_list(obj),
     }
 
     return obj, metadata

--- a/utils/tasks.py
+++ b/utils/tasks.py
@@ -173,16 +173,17 @@ def create_zipfile(data_dump_filename, dsid=None, collid=None):
         metadata = dataset_to_json(dsid) if dsid else collection_to_json(collid)
         pretty_metadata = json.dumps(metadata, indent=1, sort_keys=False)
         dl_class = "Dataset" if dsid else "Collection"
+        # Truthful per-object licence statement: the source licence (when
+        # recorded) plus WHG's aggregation overlay — not a hard-coded constant.
+        # See licensing/rights.py (citations design §4.3).
+        from licensing.rights import rights_statement_text
+        obj = (Dataset.objects.filter(id=dsid).first() if dsid
+               else Collection.objects.filter(id=collid).first())
+        licence_statement = rights_statement_text(obj) if obj else ""
         readme_content = (f'World Historical Gazetteer (WHG)\n{dl_class} Download\n'
                           f'data: {os.path.basename(data_dump_filename)}\n'
                           '********************************\n'
-                          'This dataset conforms to the CC-BY 4.0 NC license.\n\n'
-                          "This license enables reusers to distribute, remix, adapt, and build upon the material "
-                          "in any medium or format for noncommercial purposes only, and only so long as attribution "
-                          "is given to the creator. CC BY-NC includes the following elements:\n"
-                          "* Attribution — You must give appropriate credit, provide a link to the license, and indicate "
-                          "if changes were made.\n"
-                          "* NonCommercial — You may not use the material for commercial purposes.\n\n"
+                          + licence_statement + "\n\n"
                           "***********************************\n"
                           "Metadata:\n" + pretty_metadata)
 


### PR DESCRIPTION
**Phase 5a** of the citations design — the consolidation phase's legal-risk core. Replaces the three remaining **hard-coded `CC-BY-NC-4.0`** assertions with the object's *actual* `License` (added in Phase 1) asserted **alongside** WHG's aggregation overlay — fixing the defect of stamping `-NC` over ODbL / ODC-By / public-domain source data (design §1.3 defect 1, decisions 1+2).

## Changes
- **`licensing/rights.py`** (new) — one code path for all three surfaces:
  - `datacite_rights_list(obj)` → DataCite `rightsList`: source licence (when recorded) **prepended**, WHG overlay **always present**; overlay-only when no source licence (never fabricated). Guards against the legacy `Link.license` CharField (only emits real `License` rows).
  - `rights_statement_text(obj)` → human-readable statement naming the source licence + any `rights_statement` + the overlay.
- **`utils/doi.py`** — `rightsList` now `datacite_rights_list(obj)` (was a hard-coded single CC-BY-NC-4.0 entry).
- **`api/download_file.py`** — LPF envelope `license` now `rights_statement_text(obj)`.
- **`utils/tasks.py`** — export `README.txt` licence now `rights_statement_text(obj)` (resolves the Dataset/Collection from `dsid`/`collid`).

## Validation (container vs dev Postgres, throwaway test DB)
- `manage.py check` — clean
- `manage.py test licensing api.tests_attribution persons` — **45/45 OK** (+5 new `RightsHelperTests`)

## Scope note
This is 5a (rights truthfulness). The rest of Phase 5 — the unified `includes/_attribution.html` partial (5c) and retiring the dead `Dataset.creators_csl`/`contributors_csl` M2M (5b) — follow as separate PRs. Multi-source *aggregate* rights enumeration for collections (per-constituent licence lists) is a noted extension point on the helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)