### PR TITLE
Citations Phase 5c — unified _attribution.html display partial

### DIFF
--- a/collection/templates/collection/ds_collection_browse.html
+++ b/collection/templates/collection/ds_collection_browse.html
@@ -102,7 +102,7 @@
 						<div class="">
 							<div data-csl-json="{{ object.citation_csl }}"></div>
 							{% if object.license %}
-								<div class="mt-1">{% include "licensing/_license_badge.html" with license=object.license rights_statement=object.rights_statement %}</div>
+								<div class="mt-1">{% include "includes/_attribution.html" with license=object.license rights_statement=object.rights_statement contributions=contributions %}</div>
 							{% endif %}
 							<p>
 								<span class="float-end">

--- a/collection/templates/collection/place_collection_browse.html
+++ b/collection/templates/collection/place_collection_browse.html
@@ -107,7 +107,7 @@
 						</table>
 						<div data-csl-json="{{ object.citation_csl }}"></div>
 						{% if object.license %}
-							<div class="mt-1">{% include "licensing/_license_badge.html" with license=object.license rights_statement=object.rights_statement %}</div>
+							<div class="mt-1">{% include "includes/_attribution.html" with license=object.license rights_statement=object.rights_statement contributions=contributions %}</div>
 						{% endif %}
 						<div class="">
 							<p>

--- a/collection/views.py
+++ b/collection/views.py
@@ -1000,6 +1000,8 @@ class PlaceCollectionBrowseView(DetailView):
         context['media_url'] = settings.MEDIA_URL
 
         context['is_admin'] = True if self.request.user.groups.filter(name__in=['whg_admins']).exists() else False
+        # Read-only CRediT credit for the unified attribution partial (§4.4).
+        context['contributions'] = _credit_context(coll, self.request.user)['contributions']
         context['ds_list'] = coll.ds_list
         context['num_places'] = coll.num_places
         context['ds_counter'] = coll.ds_counter
@@ -1352,6 +1354,8 @@ class DatasetCollectionBrowseView(DetailView):
         # context['ds_list'] = coll.ds_list
         context['links'] = Link.objects.filter(collection=id_)
         context['updates'] = {}
+        # Read-only CRediT credit for the unified attribution partial (§4.4).
+        context['contributions'] = _credit_context(coll, self.request.user)['contributions']
         context['is_admin'] = True if self.request.user.groups.filter(name__in=['whg_admins']).exists() else False
         context[
             'visParameters'] = coll.vis_parameters or "{'seq': {'tabulate': false, 'temporal_control': 'none', 'trail': false},'min': {'tabulate': false, 'temporal_control': 'none', 'trail': false},'max': {'tabulate': false, 'temporal_control': 'none', 'trail': false}}"

--- a/datasets/templates/datasets/ds_metadata.html
+++ b/datasets/templates/datasets/ds_metadata.html
@@ -290,7 +290,8 @@
                           <td class="fw-bold">License</td>
                           <td>
                             {% if ds.license %}
-                              {% include "licensing/_license_badge.html" with license=ds.license rights_statement=ds.rights_statement %}
+                              {# Unified attribution partial; contributors omitted here — the editor widget above handles them. #}
+                              {% include "includes/_attribution.html" with license=ds.license rights_statement=ds.rights_statement %}
                             {% else %}
                               <a href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank" rel="noopener">CC BY-NC 4.0</a>
                             {% endif %}

--- a/licensing/tests.py
+++ b/licensing/tests.py
@@ -56,6 +56,59 @@ class LicenseBadgeTests(TestCase):
         self.assertEqual(self._render(license=None), "")
 
 
+class _Person:
+    def __init__(self, name, orcid=""):
+        self._name = name
+        self.orcid = orcid
+
+    def __str__(self):
+        return self._name
+
+
+class _Contribution:
+    """Stand-in for persons.Contribution for template-render tests."""
+    def __init__(self, role, role_display, person, is_corresponding=False):
+        self.role = role
+        self._role_display = role_display
+        self.person = person
+        self.is_corresponding = is_corresponding
+
+    def get_role_display(self):
+        return self._role_display
+
+
+class AttributionPartialTests(TestCase):
+    """includes/_attribution.html — unified display partial (§4.4)."""
+    TPL = '{% include "includes/_attribution.html" %}'
+
+    def _render(self, **ctx):
+        return Template(self.TPL).render(Context(ctx)).strip()
+
+    def test_license_badge_without_contributors(self):
+        lic = License.objects.get(spdx_id="CC-BY-4.0")
+        html = self._render(license=lic)
+        self.assertIn("CC-BY-4.0", html)
+        self.assertNotIn("Credited contributors", html)
+
+    def test_contributors_grouped_by_role(self):
+        ed = _Person("A. Editor", orcid="0000-0001-2345-6789")
+        wr = _Person("B. Writer")
+        contribs = [
+            _Contribution("writing-original-draft", "Writing – original draft", wr),
+            _Contribution("data-curation", "Data curation", ed, is_corresponding=True),
+        ]
+        html = self._render(license=None, contributions=contribs)
+        self.assertIn("Credited contributors", html)
+        self.assertIn("Data curation", html)
+        self.assertIn("Writing – original draft", html)
+        self.assertIn("A. Editor", html)
+        self.assertIn("orcid.org/0000-0001-2345-6789", html)
+        self.assertIn("corresponding", html)
+
+    def test_empty_when_nothing_supplied(self):
+        self.assertNotIn("Credited contributors", self._render())
+
+
 class RightsHelperTests(TestCase):
     """licensing.rights — truthful per-object rights (citations §4.2–4.3).
     The WHG overlay (settings.WHG_OVERLAY_LICENSE) is CC-BY-NC-4.0."""

--- a/main/templates/includes/_attribution.html
+++ b/main/templates/includes/_attribution.html
@@ -1,0 +1,36 @@
+{% comment %}
+Unified attribution DISPLAY partial (citations design §4.4).
+
+Read-only consolidation of the source-licence badge, an optional citation, and
+the contributor credit grouped by CRediT role. Reused across dataset/collection
+browse + metadata surfaces. The owner/staff *editor* is a separate widget
+(includes/_credit_contributors.html); this partial never renders edit controls.
+
+Context (all optional — render only what's supplied):
+  license           a licensing.License instance         -> licence badge
+  rights_statement  free-text rights                     -> shown under badge
+  contributions     queryset/list of persons.Contribution -> credit by role
+  citation_html     pre-rendered, trusted citation markup -> shown above badge
+{% endcomment %}
+<div class="whg-attribution">
+  {% if citation_html %}<div class="small mb-1">{{ citation_html }}</div>{% endif %}
+
+  {% include "licensing/_license_badge.html" with license=license rights_statement=rights_statement %}
+
+  {% if contributions %}
+    <div class="small mt-2" id="attribution-credit">
+      <span class="fw-bold">Credited contributors</span>
+      <a href="https://credit.niso.org/" target="_blank" rel="noopener"
+         data-bs-toggle="tooltip" data-bs-title="Contributor Roles Taxonomy">
+        <i class="fas fa-question-circle fa-xs"></i></a>
+      {% regroup contributions|dictsort:"role" by get_role_display as role_groups %}
+      <ul class="list-unstyled mb-0">
+        {% for grp in role_groups %}
+          <li><span class="text-muted">{{ grp.grouper }}:</span>
+            {% for c in grp.list %}{{ c.person }}{% if c.person.orcid %} <a href="https://orcid.org/{{ c.person.orcid }}" target="_blank" rel="noopener" title="ORCiD"><i class="fab fa-orcid"></i></a>{% endif %}{% if c.is_corresponding %} <span class="badge bg-light text-dark border">corresponding</span>{% endif %}{% if not forloop.last %};{% endif %}{% endfor %}
+          </li>
+        {% endfor %}
+      </ul>
+    </div>
+  {% endif %}
+</div>


### PR DESCRIPTION
**Phase 5c** — the final consolidation piece: a single attribution **display** partial, `includes/_attribution.html` (citations design §4.4).

## What it does
Consolidates the source-licence badge + optional citation + read-only contributor credit (grouped by CRediT role) into one reusable partial. The owner/staff **editor** stays separate (`includes/_credit_contributors.html`); `_attribution.html` never renders edit controls. All context is optional, so callers render only what they supply.

## Changes
- **`includes/_attribution.html`** (new) — includes `_license_badge.html`, regroups `contributions` by `get_role_display`, optional `citation_html`.
- Repoint the three bare `_license_badge.html` includes:
  - `ds_metadata.html` — badge-only (the editor widget already lists contributors there, so no duplication).
  - `ds_collection_browse.html` + `place_collection_browse.html` — badge **+ contributors-by-role**.
- The two collection browse views now pass a read-only `contributions` queryset (reusing `_credit_context`), so CRediT credit surfaces on the public collection pages for the first time.
- `licensing/tests.py` — 3 `AttributionPartialTests`.

## Validation (container vs dev Postgres)
- `manage.py test licensing api.tests_attribution persons` — **48/48 OK** (+3)
- All four affected templates compile (`get_template`)

## Phase 5 complete
With 5a (licence truthfulness), 5b (retire dead M2M), and 5c (unified partial), Phase 5 is done. Remaining citations work: **Phase 6** (the indexing-repo handoff — committed to the indexing repo, ready to execute), plus noted extension points (per-constituent rights lists for multi-source collection downloads; the §3.1 `Link.license` CharField→FK migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)