### PR TITLE
Phase 6 support — seed CC-BY-ND-4.0 + 3 custom authority licence rows

### DIFF
--- a/licensing/migrations/0003_seed_phase6_licenses.py
+++ b/licensing/migrations/0003_seed_phase6_licenses.py
@@ -1,0 +1,74 @@
+from django.db import migrations
+
+# Licence rows requested by the Phase 6 indexing-repo audit
+# (indexing/developer/handoff-citation-metadata.md §3):
+#
+#   * CC-BY-ND-4.0 — the one genuine SPDX licence not in the 0002 seed set
+#     (needed by the DGSD authority; indexing already sends this license_spdx).
+#   * three custom=True rows for bespoke, non-SPDX source terms. Their spdx_id
+#     values are WHG-local lookup keys (custom- prefix, mirroring
+#     custom-public-domain) — the indexing AUTHORITIES entries set
+#     ``license_spdx`` to these so the inventory push can resolve the FK:
+#       nl    -> custom-nativeland-dst
+#       ukhc  -> custom-historic-counties
+#       chgis -> custom-chgis-academic
+#
+# url values mirror each source's verified license_url so the registry deed
+# link matches what the push sends.
+#
+# tuple: (spdx_id, label, url, permits_commercial, share_alike,
+#         attribution_required, custom, notes)
+SEED = [
+    ("CC-BY-ND-4.0",
+     "Creative Commons Attribution-NoDerivatives 4.0 International",
+     "https://creativecommons.org/licenses/by-nd/4.0/",
+     True, False, True, False,
+     "No derivatives. Used by DGSD (endorsed for WHG use by its author)."),
+
+    ("custom-nativeland-dst",
+     "Native Land Digital — Data Sovereignty Treaty",
+     "https://api-docs.native-land.ca/data-sovereignty-treaty",
+     False, False, True, True,
+     "Non-commercial; redistribution by permission. Indigenous communities "
+     "are the rightful stewards of this data (OCAP®)."),
+
+    ("custom-historic-counties",
+     "Historic Counties Trust — Permissive Terms",
+     "https://county-borders.co.uk/",
+     True, False, True, True,
+     "Bespoke permissive terms; commercial use allowed; attribution requested."),
+
+    ("custom-chgis-academic",
+     "CHGIS — Academic Research Only",
+     "https://chgis.fas.harvard.edu/data/chgis/v6/",
+     False, False, True, True,
+     "Academic research only; no commercial use, resale, or redistribution."),
+]
+
+_FIELDS = ("label", "url", "permits_commercial", "share_alike",
+           "attribution_required", "custom", "notes")
+
+
+def seed(apps, schema_editor):
+    License = apps.get_model("licensing", "License")
+    for spdx_id, *values in SEED:
+        License.objects.update_or_create(
+            spdx_id=spdx_id,
+            defaults=dict(zip(_FIELDS, values)),
+        )
+
+
+def unseed(apps, schema_editor):
+    License = apps.get_model("licensing", "License")
+    License.objects.filter(spdx_id__in=[row[0] for row in SEED]).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("licensing", "0002_seed_licenses"),
+    ]
+
+    operations = [
+        migrations.RunPython(seed, unseed),
+    ]

--- a/licensing/tests.py
+++ b/licensing/tests.py
@@ -22,12 +22,27 @@ class LicenseSeedTests(TestCase):
     rows are present without re-running anything here."""
 
     def test_seed_rows_present(self):
-        self.assertEqual(License.objects.count(), 8)
+        # 8 from 0002 + 4 from 0003 (Phase 6: CC-BY-ND-4.0 + 3 custom rows).
+        self.assertEqual(License.objects.count(), 12)
 
     def test_flag_semantics(self):
         self.assertFalse(License.objects.get(spdx_id="CC0-1.0").attribution_required)
         self.assertTrue(License.objects.get(spdx_id="ODbL-1.0").share_alike)
         self.assertFalse(License.objects.get(spdx_id="CC-BY-NC-4.0").permits_commercial)
+
+    def test_phase6_rows(self):
+        # The one genuine SPDX addition.
+        nd = License.objects.get(spdx_id="CC-BY-ND-4.0")
+        self.assertFalse(nd.custom)
+        self.assertTrue(nd.permits_commercial)
+        # The three bespoke non-SPDX rows.
+        for key in ("custom-nativeland-dst", "custom-historic-counties",
+                    "custom-chgis-academic"):
+            self.assertTrue(License.objects.get(spdx_id=key).custom, key)
+        # Non-commercial terms flagged as such; permissive one is not.
+        self.assertFalse(License.objects.get(spdx_id="custom-nativeland-dst").permits_commercial)
+        self.assertFalse(License.objects.get(spdx_id="custom-chgis-academic").permits_commercial)
+        self.assertTrue(License.objects.get(spdx_id="custom-historic-counties").permits_commercial)
 
     def test_spdx_url(self):
         self.assertEqual(


### PR DESCRIPTION
WHG-side support for the **Phase 6 indexing audit** (`indexing/developer/handoff-citation-metadata.md` §3). The audit verified every authority's real licence and surfaced four licence rows WHG needs to seed so the inventory push can resolve the `license` FK.

## `licensing/0003_seed_phase6_licenses` adds
| spdx_id (lookup key) | for | commercial | custom | notes |
|---|---|---|---|---|
| `CC-BY-ND-4.0` | DGSD (`dgsd`) | ✓ | no | genuine SPDX; DGSD already sends this `license_spdx` |
| `custom-nativeland-dst` | NativeLand (`nl`) | ✗ | yes | Data Sovereignty Treaty: NC + redistribution-by-permission |
| `custom-historic-counties` | UK Historic Counties (`ukhc`) | ✓ | yes | permissive; attribution requested |
| `custom-chgis-academic` | CHGIS (`chgis`) | ✗ | yes | academic-only; no commercial/resale/redistribution |

The three custom `spdx_id` values are WHG-local lookup keys (`custom-` prefix, mirroring the existing `custom-public-domain`). Their `url` mirrors each source's verified `license_url`.

## Indexing-side coordination
`dgsd` already sets `license_spdx: 'CC-BY-ND-4.0'` — resolves once this deploys. The three custom namespaces currently **omit** `license_spdx`; they should set it to the matching key above so the push resolves the FK (otherwise those rows push citation/url/rights_holder but no licence FK, which is the safe interim).

## Validation
- `manage.py test licensing` — **15/15 OK** (seed-count assertion updated 8 → 12; new `test_phase6_rows`)
- Data migration only (no schema change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)