### PR TITLE
Link out to external Baserow dataset-submission form

### DIFF
--- a/developer/baserow-workflow-tool.md
+++ b/developer/baserow-workflow-tool.md
@@ -35,18 +35,19 @@ A stable internal URL that redirects to the external form:
 | Nav | `base_webpack.html` → "Submit a Dataset" in the **Data** dropdown |
 
 Why a redirect view rather than a raw external link in the nav: the public form
-URL isn't known yet (Palak will share it), and a stable `/contribute/` lets the
-external target change without touching templates. Until the URL is set the view
-redirects home with an info message, so the nav item is safe to ship now.
+a stable `/contribute/` lets the external target change without touching
+templates, and if the URL is ever unset the view redirects home with an info
+message instead of erroring.
 
-### To go live
+### Live URL
 
-1. Get the public form URL from Palak.
-2. Set it in `whg/local_settings.py` (or env):
-   ```python
-   BASEROW_SUBMIT_FORM_URL = 'https://baserow.io/form/XXXXXXXX'
-   ```
-   No restart-time secret — it's just a public URL.
+The form is **live** — `https://baserow.io/form/VhZUnWUX7JXiP9BYX2VbBFc7tLCdZGWYKtSuoN7RxVU`
+("Submit Your Dataset to WHG") — and is baked in as the default for
+`BASEROW_SUBMIT_FORM_URL` in `whg/settings.py`. It's a public URL, not a secret,
+so the `/contribute/` link works on every deployment as soon as this merges — no
+per-server config. To override (e.g. if the form is rebuilt), set
+`BASEROW_SUBMIT_FORM_URL` via env var or `local_settings.py`; precedence is
+env > local_settings > the baked default.
 
 ### Optional later: embedding / API sync
 

--- a/developer/baserow-workflow-tool.md
+++ b/developer/baserow-workflow-tool.md
@@ -1,0 +1,91 @@
+# Dataset / Gazetteer Workflow Tool — Baserow (external)
+
+> Branch: `feature/baserow-submit-link` (off `main`)
+> Supersedes the in-codebase Django `leads` app (see "Teardown" below).
+
+## Decision
+
+Lead/dataset/submission tracking lives in **Baserow** — an open-source,
+free-tier Airtable alternative — built and owned by Palak **outside this
+codebase**. We do **not** model any of this in Django. The website's only job is
+to **link out** to Baserow's public submission form.
+
+This replaces the earlier Django `leads` app prototype (DatasetLead model, admin
+triage UI, public form, Zotero/gap-value services), which was built on `atlas`
+and is now being retired.
+
+## Baserow workspace (Palak)
+
+Tables: **Datasets** (intake → publication status), **Projects** (linked to
+Datasets), **Contacts/Submitters**, plus the **Gazetteer Bibliography**.
+A public form, *"Submit Your Dataset to WHG,"* writes straight into the Datasets
+table, and an automation emails the team on each new submission.
+
+Database IDs / token were shared by Palak by email — **not stored in this repo.**
+
+## What this branch adds (the only Django footprint)
+
+A stable internal URL that redirects to the external form:
+
+| Piece | Location |
+|-------|----------|
+| Config | `whg/settings.py` → `BASEROW_SUBMIT_FORM_URL` (env / `local_settings.py`) |
+| View | `main/views.py` → `submit_dataset` (302 to the form; graceful fallback if unset) |
+| URL | `whg/urls.py` → `path('contribute/', …, name='submit-dataset')` |
+| Nav | `base_webpack.html` → "Submit a Dataset" in the **Data** dropdown |
+
+Why a redirect view rather than a raw external link in the nav: the public form
+URL isn't known yet (Palak will share it), and a stable `/contribute/` lets the
+external target change without touching templates. Until the URL is set the view
+redirects home with an info message, so the nav item is safe to ship now.
+
+### To go live
+
+1. Get the public form URL from Palak.
+2. Set it in `whg/local_settings.py` (or env):
+   ```python
+   BASEROW_SUBMIT_FORM_URL = 'https://baserow.io/form/XXXXXXXX'
+   ```
+   No restart-time secret — it's just a public URL.
+
+### Optional later: embedding / API sync
+
+Not built here (we chose "link out only"). If wanted later:
+- **Embed** — swap the redirect for a page with an `<iframe>` of the form.
+- **API sync** — Palak's token (`Database Token`, full read/write) could let
+  Django read submissions or update status flags. If so, it goes in
+  `local_settings.py` / secrets **only** — never committed. The token has been
+  shared by email in the clear, so ask Palak to **rotate** it before any
+  programmatic use.
+
+## Teardown of the old Django `leads` app
+
+The `leads` app exists **only on `atlas`** (commits `c7558b0…` ff). `main` never
+had it, so this branch adds the Baserow link **without removing any code** — the
+two are independent.
+
+Because new work now goes **straight to `main`, bypassing `atlas`**, the leads
+app gets dropped simply by `main` not containing it. Two cleanup items remain:
+
+1. **Deployed dev database.** The dev server (running `atlas`) has a
+   `leads_datasetlead` table with ~72 seeded rows. Once the deployment tracks
+   `main`, the app code is gone, so you can't `migrate leads zero`. Drop the
+   orphaned table directly:
+   ```sql
+   DROP TABLE IF EXISTS leads_datasetlead CASCADE;
+   DELETE FROM django_migrations WHERE app = 'leads';
+   ```
+   (The data is superseded by Baserow / the bibliography spreadsheet.)
+   Alternatively, while still on `atlas`, run `python manage.py migrate leads zero`
+   first — the clean path — then abandon the branch.
+
+2. **Obsolete branches.** `feature/dataset-leads` (off `main`, plan docs only,
+   local, never pushed) is superseded — safe to delete:
+   `git branch -D feature/dataset-leads`. The `leads` commits on `atlas` should
+   not be merged forward to `main`.
+
+## References
+
+- Palak's update email + API-token email (Baserow workspace).
+- Source bibliography: `WHG_gazetteer_bibliography.xlsx` (now lives in Baserow's
+  Gazetteer Bibliography table).

--- a/main/templates/main/base_webpack.html
+++ b/main/templates/main/base_webpack.html
@@ -261,6 +261,9 @@
                     <li>
                         <a class="dropdown-item" href="{% url 'datasets:volunteer-requests' %}">Volunteering</a>
                     </li>
+                    <li>
+                        <a class="dropdown-item" href="{% url 'submit-dataset' %}">Submit a Dataset</a>
+                    </li>
                 </ul>
                 </li>
                 <li class="nav-item">

--- a/main/views.py
+++ b/main/views.py
@@ -476,6 +476,18 @@ def group_list(request, sort='', order=''):
     return render(request, 'lists/group_list.html', context)
 
 
+# Link out to the external Baserow "Submit Your Dataset to WHG" form.
+# The workflow tool itself lives outside this codebase (Baserow workspace);
+# we keep a stable internal URL so the external target can change without
+# touching templates. Falls back gracefully until the form URL is configured.
+def submit_dataset(request):
+    url = getattr(settings, 'BASEROW_SUBMIT_FORM_URL', '')
+    if url:
+        return redirect(url)
+    messages.info(request, "Dataset submission is being set up — please check back soon, or contact us in the meantime.")
+    return redirect('home')
+
+
 # gets the correct view based on user group
 @login_required
 def dashboard_redirect(request):

--- a/whg/settings.py
+++ b/whg/settings.py
@@ -48,6 +48,11 @@ CRC_GATEWAY_URL = os.environ.get('CRC_GATEWAY_URL') or globals().get('CRC_GATEWA
 CRC_GATEWAY_API_KEY = os.environ.get('CRC_GATEWAY_API_KEY') or globals().get('CRC_GATEWAY_API_KEY', '')
 CRC_GATEWAY_TIMEOUT = int(os.environ.get('CRC_GATEWAY_TIMEOUT') or globals().get('CRC_GATEWAY_TIMEOUT', 10))
 
+# Baserow dataset-submission workflow tool (external SaaS — runs outside this codebase).
+# Public submission form is hosted in Palak's Baserow workspace; we only link out to it.
+# Set BASEROW_SUBMIT_FORM_URL in env vars or local_settings once the form URL is shared.
+BASEROW_SUBMIT_FORM_URL = os.environ.get('BASEROW_SUBMIT_FORM_URL') or globals().get('BASEROW_SUBMIT_FORM_URL', '')
+
 DATABASES['default']['CONN_MAX_AGE'] = 600  # 10 minutes
 
 if 'test' in sys.argv:

--- a/whg/settings.py
+++ b/whg/settings.py
@@ -49,9 +49,14 @@ CRC_GATEWAY_API_KEY = os.environ.get('CRC_GATEWAY_API_KEY') or globals().get('CR
 CRC_GATEWAY_TIMEOUT = int(os.environ.get('CRC_GATEWAY_TIMEOUT') or globals().get('CRC_GATEWAY_TIMEOUT', 10))
 
 # Baserow dataset-submission workflow tool (external SaaS — runs outside this codebase).
-# Public submission form is hosted in Palak's Baserow workspace; we only link out to it.
-# Set BASEROW_SUBMIT_FORM_URL in env vars or local_settings once the form URL is shared.
-BASEROW_SUBMIT_FORM_URL = os.environ.get('BASEROW_SUBMIT_FORM_URL') or globals().get('BASEROW_SUBMIT_FORM_URL', '')
+# Public "Submit Your Dataset to WHG" form, hosted in Palak's Baserow workspace; we only
+# link out to it from /contribute/. The default below is the live public form URL (not a
+# secret); override via env var or local_settings if it ever changes.
+BASEROW_SUBMIT_FORM_URL = (
+    os.environ.get('BASEROW_SUBMIT_FORM_URL')
+    or globals().get('BASEROW_SUBMIT_FORM_URL')
+    or 'https://baserow.io/form/VhZUnWUX7JXiP9BYX2VbBFc7tLCdZGWYKtSuoN7RxVU'
+)
 
 DATABASES['default']['CONN_MAX_AGE'] = 600  # 10 minutes
 

--- a/whg/urls.py
+++ b/whg/urls.py
@@ -58,6 +58,9 @@ urlpatterns = [
                   # home page
                   path('', views.Home30a.as_view(), name="home"),
 
+                  # link out to the external Baserow dataset-submission form
+                  path('contribute/', views.submit_dataset, name="submit-dataset"),
+
                   # apps
                   path('areas/', include('areas.urls')),
                   path('collections/', include('collection.urls')),


### PR DESCRIPTION
## Summary

Dataset/submission lead tracking now lives in **Baserow** (open-source Airtable alternative), built and owned by Palak **outside this codebase**. This PR adds the only Django footprint needed: a stable internal URL that links out to Baserow's public *"Submit Your Dataset to WHG"* form.

This supersedes the earlier Django `leads` app prototype (which lived only on `atlas`, never on `main`).

## Changes

- **`whg/settings.py`** — `BASEROW_SUBMIT_FORM_URL` (env / `local_settings.py`, same pattern as `CRC_GATEWAY_URL`).
- **`main/views.py`** — `submit_dataset`: 302 to the Baserow form; graceful fallback (redirect home + info message) until the URL is configured.
- **`whg/urls.py`** — `path('contribute/', …, name='submit-dataset')`.
- **`base_webpack.html`** — "Submit a Dataset" in the **Data** nav dropdown.
- **`developer/baserow-workflow-tool.md`** — design, go-live step, optional embed/API-sync, and teardown notes for the old `leads` app.

No Django models, no API token committed.

## To go live

1. Get the public form URL from Palak.
2. Set `BASEROW_SUBMIT_FORM_URL` in `local_settings.py` (or env). It's a public URL — no secret.

## Old `leads` app teardown

`main` never had `leads`, so this PR adds the link without removing any code. The atlas deployment + its `leads_datasetlead` DB table are being cleaned up separately on the dev server. See `developer/baserow-workflow-tool.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)