### PR TITLE
Fix: silence redirect_to template-noise on place portal views

### DIFF
--- a/places/views.py
+++ b/places/views.py
@@ -100,8 +100,12 @@ class PlacePortalView(TemplateView):
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(**kwargs)
+        # Always present so the template's {% if redirect_to %} resolves cleanly;
+        # only the single-match branch below sets a real redirect target. Without
+        # this default, every normal portal view logs a VariableDoesNotExist traceback.
+        context['redirect_to'] = None
         me = self.request.user
-        
+
         filter_condition = Q(collection_class='place')
         if me.is_authenticated:
             filter_condition &= (Q(owner=me) | Q(collabs__user=me))


### PR DESCRIPTION
## Summary

Every normal `/places/<id>/portal/` view logs a full `VariableDoesNotExist` traceback (surfacing as `AttributeError` / `ValueError` / `VariableDoesNotExist` — Django's dict→attr→index resolution cascade). The page itself returns **200** and renders fine; this is log noise, not a functional bug.

**Cause:** `place_portal.html:8` opens with `{% if redirect_to %}`, but `PlacePortalView.get_context_data` only sets `redirect_to` in the single-match (deprecated-place) branch. For the normal multi-match case the variable is absent, so the template lookup fails and Django logs the traceback at DEBUG before recovering.

**Fix:** default `context['redirect_to'] = None` at the top of `get_context_data`, so the template lookup always resolves. One line, no behaviour change (`PlaceFullView` inherits the fix too).

## Follow-up (separate)

The single-match branch returns `{'redirect_to': ...}` from `get_context_data` to drive a client-side JS bounce, which re-renders the whole template with the other context vars missing. A cleaner server-side `redirect()` in `get()` is tracked separately — not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)