### PR TITLE
Server-side redirect for single-match place portal (follow-up to #538)

### DIFF
--- a/places/templates/places/place_portal.html
+++ b/places/templates/places/place_portal.html
@@ -5,10 +5,6 @@
 
 {% block maplibre %}
 
-  {% if redirect_to %}
-    <script>window.location.href = "{{ redirect_to }}";</script>
-  {% endif %}
-
   <script type="text/javascript">
     const loadMaplibre = true;
   </script>

--- a/places/views.py
+++ b/places/views.py
@@ -98,12 +98,19 @@ class PlaceDetailView(DetailView):
 class PlacePortalView(TemplateView):
     template_name = 'places/place_portal.html'
 
+    def get(self, request, *args, **kwargs):
+        # A place with a single match has no portal to show — redirect server-side
+        # (302) to its detail page. Matches are stashed so get_context_data doesn't
+        # recompute the (N+1) .matches query on the multi-match path.
+        pid = kwargs.get('pid')
+        if pid is not None:
+            self._portal_matches = Place.objects.get(id=pid).matches
+            if len(self._portal_matches) == 1:
+                return redirect(f'/places/{pid}/detail')
+        return super().get(request, *args, **kwargs)
+
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(**kwargs)
-        # Always present so the template's {% if redirect_to %} resolves cleanly;
-        # only the single-match branch below sets a real redirect target. Without
-        # this default, every normal portal view logs a VariableDoesNotExist traceback.
-        context['redirect_to'] = None
         me = self.request.user
 
         filter_condition = Q(collection_class='place')
@@ -117,9 +124,9 @@ class PlacePortalView(TemplateView):
         place_ids = []
 
         if pid:
-            portal_data = Place.objects.get(id=pid).matches
-            if len(portal_data) == 1:
-                return {'redirect_to': f'/places/{pid}/detail'}
+            portal_data = getattr(self, '_portal_matches', None)
+            if portal_data is None:
+                portal_data = Place.objects.get(id=pid).matches
             place_ids = [place.id for place in portal_data]
         elif whg_id:
             place_ids = findPortalPlaces(whg_id)


### PR DESCRIPTION
## Summary

Follow-up to #538. Replaces the client-side redirect hack for single-match place portals with a proper server-side 302.

**Before:** for a place with a single match, `PlacePortalView.get_context_data` returned a partial context `{'redirect_to': ...}`, and the template emitted `<script>window.location.href = ...</script>`. That re-rendered the entire portal template server-side with the other context vars missing (its own `VariableDoesNotExist` burst) and was slower/worse for SEO than a real redirect.

**After:** a `get()` override issues `redirect('/places/<pid>/detail')` when the place has a single match. The `.matches` result (a `CloseMatch` query + per-place `links.count()`) is computed once in `get()` and stashed so `get_context_data` doesn't recompute it on the multi-match path. The `{% if redirect_to %}` block and the `redirect_to = None` default from #538 are removed.

`PlaceFullView` (subclass, JSON, routed by `id` not `pid`) is unaffected — `pid` is `None`, so it falls through to the normal render.

## Test

- Single-match place portal → 302 to `/places/<pid>/detail`
- Multi-match place portal → 200, renders normally, no `redirect_to` noise

🤖 Generated with [Claude Code](https://claude.com/claude-code)