### PR TITLE
Relabel nav to 'Suggest a Source' + fix portal title template-noise

### DIFF
--- a/main/templates/main/base_webpack.html
+++ b/main/templates/main/base_webpack.html
@@ -262,7 +262,7 @@
                         <a class="dropdown-item" href="{% url 'datasets:volunteer-requests' %}">Volunteering</a>
                     </li>
                     <li>
-                        <a class="dropdown-item" href="{% url 'submit-dataset' %}">Submit a Dataset</a>
+                        <a class="dropdown-item" href="{% url 'submit-dataset' %}">Suggest a Source</a>
                     </li>
                 </ul>
                 </li>

--- a/places/templates/places/place_portal.html
+++ b/places/templates/places/place_portal.html
@@ -16,7 +16,7 @@
 {% endblock %}
 
 {% block title %}
-  <title>Place::{{ place.title }}</title>
+  <title>Place::{{ portal_headword|default:"" }}</title>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
Interim nav relabel ('Submit a Dataset' → 'Suggest a Source') to stop it colliding with the self-service `/datasets/validate/` route (link target unchanged, pending a two-doors scope decision with Ruth/Palak), plus fixes the `{{ place.title }}` → `portal_headword` title-block noise on place portal renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)