### PR TITLE
security(deps): Python runtime CVE bumps — issue #119 Group A (8 packages)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ bs4==0.0.1
 cached-property==1.5.2
 celery>=5.3,<6
 celery-progress==0.1.3
-certifi==2022.12.7
+certifi==2026.6.17
 cffi==1.15.1
 chardet==3.0.4
 charset-normalizer==2.1.1
@@ -21,7 +21,7 @@ click-plugins==1.1.1
 click-repl==0.2.0
 colorama==0.4.6
 commonmark==0.9.1
-cryptography==39.0.0
+cryptography==43.0.3
 datapackage==1.15.2
 decorator==5.1.1
 deepdiff==6.2.1
@@ -74,7 +74,7 @@ geojson==3.1.0
 geopy==2.4.1
 goodtables==2.5.4
 greenlet==2.0.2
-gunicorn==21.2.0
+gunicorn==23.0.0
 humanize==4.7.0
 idna==3.4
 ijson==3.3.0
@@ -104,7 +104,7 @@ psycopg2-binary==2.9.5
 pycparser==2.21
 Pygments==2.14.0
 pyld==2.0.4
-PyJWT==2.6.0
+PyJWT==2.10.1
 pyproj==3.7.1
 pyrsistent==0.19.3
 python-dateutil==2.8.2
@@ -115,7 +115,7 @@ PyYAML==6.0
 rdflib
 rdflib-jsonld
 redis==4.5.2
-requests==2.28.1
+requests==2.32.4
 requests-oauthlib==1.3.1
 rfc3986==2.0.0
 rich==12.6.0
@@ -130,7 +130,7 @@ simplejson==3.18.1
 six==1.16.0
 soupsieve==2.4
 SQLAlchemy==1.4.46
-sqlparse==0.4.3
+sqlparse==0.5.5
 statistics==1.0.3.5
 stringcase==1.2.0
 tableschema==1.20.2
@@ -140,7 +140,7 @@ tornado==6.3.2
 typer==0.7.0
 ua-parser==0.18.0
 unicodecsv==0.14.1
-urllib3==1.26.14
+urllib3==1.26.20
 user-agents==2.2.0
 validators==0.18.2
 vine==5.0.0
@@ -148,5 +148,5 @@ wcwidth==0.2.6
 xlrd==2.0.1
 xlwt==1.3.0
 python-dotenv~=1.0.1
-Jinja2~=3.1.4
+Jinja2~=3.1.6
 ratelimit==2.2.1


### PR DESCRIPTION
Implements **Group A** of the dependency-security triage in [WHG/place#119](https://github.com/WorldHistoricalGazetteer/place/issues/119): safe patch/minor bumps of server-side Python packages to clear known CVEs. **`requirements.txt` only** — 8 lines changed.

## Bumps

| Package | From | To | CVEs cleared |
|---|---|---|---|
| `certifi` | 2022.12.7 | **2026.6.17** | CVE-2023-37920 (compromised e-Tugra root; pure CA-bundle data) |
| `cryptography` | 39.0.0 | **43.0.3** | CVE-2023-0286, -49083, -50782; CVE-2024-26130 |
| `requests` | 2.28.1 | **2.32.4** | CVE-2023-32681 (proxy-auth leak on redirect), CVE-2024-35195 |
| `urllib3` | 1.26.14 | **1.26.20** | CVE-2023-43804/-45803, CVE-2024-37891 — **stays on 1.26.x** (per #119 DO-NOT; requests pins compat) |
| `sqlparse` | 0.4.3 | **0.5.5** | CVE-2023-30608, CVE-2024-4340 (ReDoS / recursion DoS) |
| `gunicorn` | 21.2.0 | **23.0.0** | CVE-2024-1135, -6827 (HTTP request smuggling) |
| `PyJWT` | 2.6.0 | **2.10.1** | CVE-2024-53861 (issuer-claim bypass) |
| `Jinja2` | ~=3.1.4 | **~=3.1.6** | CVE-2024-56201/-56326, CVE-2025-27516 (sandbox breakout) |

Targets stay **within the recommended majors** (not absolute-latest) to keep this a genuinely low-risk PR, at/above the security minimums in #119.

## Verification done (source-level)
- **Resolver dry-run** (metadata-only) of all 8 targets **+ `Django==4.1.7`** resolves cleanly, no conflicts: cryptography 43's `cffi>=1.12` satisfied by the pinned `cffi==1.15.1`; Jinja2 3.1.6's `MarkupSafe>=2.0` OK; requests 2.32's `charset_normalizer` OK; urllib3 stays 1.26.x.
- **No transitive upper-bound conflicts**: `josepy` needs only `cryptography>=1.5`; no `pyOpenSSL` pin; nothing caps these.
- **Reachability**: no first-party code imports `cryptography` directly (only transitive via `encrypted_model_fields`/Fernet and `josepy`/OIDC — stable APIs). The sole first-party JWT use — `workbench/views.py` `jwt.encode(..., algorithm='HS256')` for Hocuspocus tokens — is API-identical across PyJWT 2.6→2.10.

## ⚠️ Deploy: needs a Docker image rebuild — NOT a plain `restart`
The web/celery services run the prebuilt Docker Hub image `worldhistoricalgazetteer/web` (compose `image:` tag, currently `1.0.13`). The repo is **bind-mounted at `/app`**, so *source* changes go live on restart — but pip packages are `pip install`-ed **inside the image** at build time (`Dockerfile`). **A `requirements.txt` change has no effect until the image is rebuilt**, per `developer/build-image.md`:

1. Build + push a new image (runs `pip install -r requirements.txt` with these bumps):
   ```bash
   python3 ./server-admin/build_docker.py patch push   # -> worldhistoricalgazetteer/web:1.0.14
   ```
2. Bump the compose `image:` tag `1.0.13` → `1.0.14` in `docker-compose-autocontext.yml` (4 occurrences: web + celery worker/beat/flower), commit.
3. Deploy so the new image is **pulled + containers recreated** (`docker compose up -d`, not `restart`): dev → verify → main → prod. No `--migrate` (no migrations).

## Verify on the rebuilt dev image (no CI test workflow in this repo)
- `python manage.py test`
- Smoke: **ORCiD OIDC login** (cryptography/PyJWT/josepy), outbound HTTPS to the **CRC gateway** (requests/urllib3/certifi), **gunicorn** starts clean.

## ⚠️ Pillow deliberately excluded (scope finding)
`Pillow` is in #119 Group A but is **NOT low-risk** here and is left for its own PR:
- Bumping to 10.x breaks **`django-resized==0.3.11`** (`Image.ANTIALIAS`, removed in Pillow 10) and **`django-simple-captcha==0.5.13`** (`font.getsize`, removed in Pillow 10).
- The Pillow-10-compatible captcha line (**0.6.x**) requires **`Django>=4.2`** — which WHG doesn't have yet.
- ⇒ **Pillow is coupled to the Django 4.2 upgrade (#119 Group B)**: do it alongside/after that, bumping `django-resized`→1.0.3 and `django-simple-captcha`→0.6.x, with image-handling (avatars, dataset thumbnails) and captcha smoke-tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)