### PR TITLE
build: layer the Dockerfile + .dockerignore so dependency bumps reuse the apt cache

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+# The Dockerfile only COPYs requirements.txt; everything else is bind-mounted at
+# runtime, so keep the build context tiny. Excluding these does NOT affect the
+# image — it just stops ~6 GB (mostly .git) being shipped to the daemon per build.
+.git
+.github
+venv
+.venv
+node_modules
+static/webpack
+static
+media
+**/__pycache__
+**/*.pyc
+**/*.pyo
+*.log
+.env
+.env/*
+developer
+scratchpad
+.idea
+.vscode
+*.sqlite3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,22 @@
+# syntax=docker/dockerfile:1
 FROM python:3.10.7-slim-bullseye
 
 LABEL maintainer="WHC @ Pitt"
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
-    MAX_MAP_COUNT=262144
+    MAX_MAP_COUNT=262144 \
+    PATH="/py/bin:$PATH"
 
 ARG USER_NAME
 
-COPY ./requirements.txt /tmp/requirements.txt
-    
+# ---------------------------------------------------------------------------
+# Layer 1 — system packages. Independent of requirements.txt, so this layer
+# stays cached across dependency bumps; it only rebuilds when this list
+# changes. (Previously apt + pip shared one RUN, so any requirements.txt edit
+# forced the slow apt-get install to re-run too.)
+# ---------------------------------------------------------------------------
 RUN set -eux; \
-    # Update package lists and install necessary packages \
     apt-get update && \
     apt-get install -y --no-install-recommends \
         # Build tools
@@ -32,25 +37,42 @@ RUN set -eux; \
         psmisc \
         # Version control
         git && \
-    # Set up fresh Python virtual environment
-    rm -rf /py && \
-    python -m venv /py && \
-    /py/bin/pip install --upgrade pip && \
-    /py/bin/pip install -r /tmp/requirements.txt && \
-    # Clean up unused packages, lists, and temporary files to reduce image size
+    # Clean up unused auto-installed packages and apt lists to reduce size
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false && \
-    rm -rf /var/lib/apt/lists/* /tmp && \
-	# Add group and user
-	groupadd -g 1000 "$USER_NAME" && \
-	useradd -rm -d "/home/$USER_NAME" -g "$USER_NAME" -s "/bin/bash" -G sudo -u 1000 "$USER_NAME" -p "$(openssl passwd -1 change_me)" && \
-	# Create a new sudoers file for the user
-	echo "$USER_NAME ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/"$USER_NAME" && \
+    rm -rf /var/lib/apt/lists/*
+
+# ---------------------------------------------------------------------------
+# Layer 2 — fresh virtualenv (cached unless the base image changes).
+# ---------------------------------------------------------------------------
+RUN rm -rf /py && \
+    python -m venv /py && \
+    /py/bin/pip install --upgrade pip
+
+# ---------------------------------------------------------------------------
+# Layer 3 — Python dependencies. The COPY makes this layer's cache key the
+# CONTENT of requirements.txt, so a dependency bump rebuilds ONLY this layer
+# (Layers 1-2 are reused). The BuildKit pip cache mount reuses downloaded
+# wheels across builds for a further speed-up.
+# ---------------------------------------------------------------------------
+COPY ./requirements.txt /tmp/requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip \
+    /py/bin/pip install -r /tmp/requirements.txt
+
+# ---------------------------------------------------------------------------
+# Layer 4 — application user + permissions (cheap, rarely changes).
+# ---------------------------------------------------------------------------
+RUN set -eux; \
+    # Add group and user
+    groupadd -g 1000 "$USER_NAME" && \
+    useradd -rm -d "/home/$USER_NAME" -g "$USER_NAME" -s "/bin/bash" -G sudo -u 1000 "$USER_NAME" -p "$(openssl passwd -1 change_me)" && \
+    # Create a new sudoers file for the user
+    echo "$USER_NAME ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/"$USER_NAME" && \
     # Set ownership
-    chown -R 1000:0 /py/lib/python3.10/site-packages/guardian/migrations/
+    chown -R 1000:0 /py/lib/python3.10/site-packages/guardian/migrations/ && \
+    # Remove the temporary requirements file (matches previous `rm -rf /tmp`)
+    rm -rf /tmp/*
 
 WORKDIR /app
-
-ENV PATH="/py/bin:$PATH"
 
 USER "$USER_NAME"
 

--- a/developer/build-image.md
+++ b/developer/build-image.md
@@ -1,18 +1,38 @@
 ## Store Versioned Images in Docker Hub
 
-###
-Helper function will calculate next version number and push built image to Docker Hub
+The web/celery services run the prebuilt image `worldhistoricalgazetteer/web:<x.x.x>`
+from Docker Hub. The repo is bind-mounted into the container at `/app`, so **source**
+changes (Python, templates, committed webpack bundles) go live on a plain deploy
+`restart`. **`requirements.txt` / pip-dependency changes are baked into the image at
+build time**, so they need a new image built + pushed, and the compose `image:` tag
+pointed at it (the version to install per environment is recorded in the DO config).
+
+### Build + push (auto-increments the Docker Hub tag)
+Helper calculates the next version number and pushes the built image to Docker Hub:
 ```bash
-# Usage: build_docker.py [major|minor|patch] [push]
+# Usage: build_docker.py [major|minor|patch] [push] [--no-cache]
 python3 ./server-admin/build_docker.py patch push
 ```
 
-#### Build image
+Builds are **cached by default**. The `Dockerfile` is layered so that:
+- system packages (apt) and the virtualenv are their own cached layers, and
+- the Python-deps layer's cache key is the **content of `requirements.txt`**.
+
+So a dependency bump rebuilds **only the pip layer** (≈1–2 min) and reuses the slow
+`apt-get install` layer. A `.dockerignore` keeps the build context tiny (the Dockerfile
+only needs `requirements.txt`; everything else is bind-mounted at runtime).
+
+Pass `--no-cache` to force a full rebuild — e.g. to refresh the base image or apt
+packages, not just Python deps:
 ```bash
-docker build --no-cache -t worldhistoricalgazetteer/web:<x.x.x> --build-arg USER_NAME=whgadmin .
+python3 ./server-admin/build_docker.py patch push --no-cache
 ```
 
-#### Push image to Docker Hub
+> Requires BuildKit (Docker ≥ 23 enables it by default) for the `# syntax` directive
+> and the pip cache mount in the `Dockerfile`.
+
+### Manual build / push
 ```bash
+docker build -t worldhistoricalgazetteer/web:<x.x.x> --build-arg USER_NAME=whgadmin .
 docker push worldhistoricalgazetteer/web:<x.x.x>
 ```

--- a/server-admin/build_docker.py
+++ b/server-admin/build_docker.py
@@ -35,18 +35,21 @@ def increment_version(version, version_type):
 
     return f"{major}.{minor}.{patch}"
 
-def build_and_tag_image(docker_image, new_version):
+def build_and_tag_image(docker_image, new_version, no_cache=False):
+    cmd = ["docker", "build"]
+    if no_cache:
+        # Full rebuild (ignores the layer cache) — use when you want to refresh
+        # the base image / apt packages, not just Python deps.
+        cmd.append("--no-cache")
+    cmd += [
+        "-t",
+        f"{docker_image}:{new_version}",
+        "--build-arg",
+        "USER_NAME=whgadmin",
+        ".",
+    ]
     try:
-        subprocess.run([
-            "docker", 
-            "build",
-            "--no-cache",
-            "-t", 
-            f"{docker_image}:{new_version}", 
-            "--build-arg", 
-            "USER_NAME=whgadmin", 
-            "."
-        ], check=True)
+        subprocess.run(cmd, check=True)
     except subprocess.CalledProcessError:
         print("Failed to build the Docker image.")
         sys.exit(1)
@@ -66,13 +69,20 @@ def main():
     # Configuration
     dockerhub_api = f"https://hub.docker.com/v2/repositories/{docker_image}/tags/"
     
-    # Handle version type and push parameter
-    if len(sys.argv) < 2 or len(sys.argv) > 3:
-        print("Usage: build_docker.py [major|minor|patch] [push]")
+    # Parse args: version type + optional `push`, with an optional `--no-cache`
+    # flag anywhere. Builds are CACHED by default now (the Dockerfile is layered
+    # so a dependency bump rebuilds only the pip layer); pass --no-cache to force
+    # a full rebuild (e.g. to refresh the base image / apt packages).
+    args = sys.argv[1:]
+    no_cache = "--no-cache" in args
+    args = [a for a in args if a != "--no-cache"]
+
+    if len(args) < 1 or len(args) > 2:
+        print("Usage: build_docker.py [major|minor|patch] [push] [--no-cache]")
         sys.exit(1)
 
-    version_type = sys.argv[1]
-    push = sys.argv[2] if len(sys.argv) == 3 else None
+    version_type = args[0]
+    push = args[1] if len(args) == 2 else None
 
     # Get the current version from Docker Hub
     current_version = get_latest_version(dockerhub_api)
@@ -83,7 +93,7 @@ def main():
     print(f"New version: {new_version}")
 
     # Build and tag the Docker image
-    build_and_tag_image(docker_image, new_version)
+    build_and_tag_image(docker_image, new_version, no_cache=no_cache)
 
     # Push the new version to Docker Hub if the push parameter is passed
     if push == "push":


### PR DESCRIPTION
Speeds up rebuilds of the `worldhistoricalgazetteer/web` image (which must be rebuilt whenever `requirements.txt` changes, since pip packages are baked into the image). Split out from the security dependency PR #543 as agreed. **No change to the installed package set or runtime behaviour** — only build context, layer structure, and speed.

## What was slow
1. **No `.dockerignore`** → every build tar'd and shipped ~6 GB of context to the daemon (mostly the 3.7 GB `.git`, plus `venv`/`node_modules`), even though the Dockerfile only `COPY`s `requirements.txt`.
2. **`apt` + `pip` in one `RUN` layer**, with `COPY requirements.txt` placed *before* it → any dependency change re-ran the slow `apt-get install` (build-essential, gdal, libpq-dev, …) as well.
3. **`build_docker.py` hardcoded `--no-cache`** → full rebuild every time.

## Changes
- **`.dockerignore`** — context drops from ~6 GB to a few KB (everything but `requirements.txt` is bind-mounted at runtime, so excluding it can't affect the image).
- **Layered `Dockerfile`** — 4 cache-friendly layers: (1) apt packages, (2) virtualenv, (3) `COPY requirements.txt` + `pip install`, (4) user/perms. A dependency bump rebuilds **only** the pip layer; the apt layer is reused. Same packages, same result.
- **BuildKit pip cache mount** (`--mount=type=cache`) reuses downloaded wheels across builds.
- **`build_docker.py`** builds **cached by default**; opt-in `--no-cache` for a full rebuild (refresh base image / apt). Flag can appear anywhere: `build_docker.py patch push [--no-cache]`.

## Measured on the build host
| Scenario | Before | After |
|---|---|---|
| Context transfer | ~6 GB (multi-min stall) | few KB (instant) |
| Warm rebuild (no change) | full `--no-cache` rebuild | **1 s** (all layers cached) |
| Dependency bump | full `--no-cache` (~3.5 min, apt re-runs) | apt layer **cached**, only pip re-runs |

Cold build validated end-to-end (exit 0, image packages correct); warm rebuild and a simulated `requirements.txt` change confirmed the apt layer stays `CACHED` while pip re-runs.

## Requirements / rollout note
- Needs **BuildKit/buildx** (for `# syntax` + the cache mount). Docker ≥23 enables BuildKit by default; the `docker-buildx-plugin` has been installed on the build host (this repo's sole image-build machine — dev/prod only *pull* from Docker Hub, so no change needed there).
- If a build host ever lacks buildx, the `RUN --mount` line would fail; the layer-reorder win itself is builder-agnostic, so that line could be dropped without losing the main benefit.

## Not included (deliberately)
- A **multi-stage build** could further shrink the runtime image by dropping `build-essential` from the final stage, but that touches the GDAL/libpq runtime libs and needs dev testing — left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)