### PR TITLE
deps: Django 4.1.7 EOL → 4.2.30 LTS + DRF 3.15.2 (issue #119 Group B)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ datapackage==1.15.2
 decorator==5.1.1
 deepdiff==6.2.1
 defusedxml==0.7.1
-Django==4.1.7
+Django==4.2.30
 django-allauth==0.53.1
 django-bootstrap-breadcrumbs==0.9.1
 django-bootstrap-modal-forms==1.4.1
@@ -57,7 +57,7 @@ django-timezone-field==5.0
 django-tinymce==3.3.0
 django-user-agents==0.4.0
 django-webpack-loader==0.6.0
-djangorestframework==3.14.0
+djangorestframework==3.15.2
 djangorestframework-datatables==0.7.0
 djangorestframework-gis==1.0
 djangorestframework-simplejwt==4.8.0
@@ -104,7 +104,7 @@ psycopg2-binary==2.9.5
 pycparser==2.21
 Pygments==2.14.0
 pyld==2.0.4
-PyJWT==2.10.1
+PyJWT==2.13.0
 pyproj==3.7.1
 pyrsistent==0.19.3
 python-dateutil==2.8.2

--- a/resources/forms.py
+++ b/resources/forms.py
@@ -3,11 +3,32 @@ from django.contrib.postgres.forms import SimpleArrayField
 from django.db import models
 from .models import Resource
 
+
+# Django 4.2 removed multiple-file support from ClearableFileInput/FileInput
+# (attrs={'multiple': True} now raises). Use the documented dedicated classes.
+class MultipleFileInput(forms.ClearableFileInput):
+    allow_multiple_selected = True
+
+
+class MultipleFileField(forms.FileField):
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("widget", MultipleFileInput())
+        super().__init__(*args, **kwargs)
+
+    def clean(self, data, initial=None):
+        single_file_clean = super().clean
+        if isinstance(data, (list, tuple)):
+            result = [single_file_clean(d, initial) for d in data]
+        else:
+            result = single_file_clean(data, initial)
+        return result
+
+
 class ResourceModelForm(forms.ModelForm):
     keywords = SimpleArrayField(forms.CharField())
     gradelevels = SimpleArrayField(forms.CharField())
-    files = forms.FileField()
-    images = forms.FileField()
+    files = MultipleFileField()
+    images = MultipleFileField()
 
     class Meta:
         model = Resource
@@ -22,8 +43,6 @@ class ResourceModelForm(forms.ModelForm):
             'description': forms.Textarea(attrs={
                 'rows': 3, 'cols': 49, 'class': 'textarea'
             }),
-            'files': forms.ClearableFileInput(attrs={'multiple': True}),
-            'images': forms.ClearableFileInput(attrs={'multiple': True})
         }
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
**Issue #119 Group B** — the headline security item: `Django==4.1.7` is **EOL** (support ended Dec 2023). An authoritative `pip-audit` of the running dep set showed Django 4.1.7 as the single largest advisory cluster (11 CVEs across PYSEC-2023/2025/2026). This bumps to the latest **4.2 LTS**.

> **Stacked on #543** (Group A security bumps). Base will be retargeted to `staging` once #543 merges. Verified end-to-end on **dev** via image `worldhistoricalgazetteer/web:1.0.15`.

## Changes (`requirements.txt`)
| Package | From | To |
|---|---|---|
| Django | 4.1.7 (EOL) | **4.2.30** LTS |
| djangorestframework | 3.14.0 | **3.15.2** (CVE-2024-21520; required for 4.2) |
| PyJWT | 2.10.1 | **2.13.0** (pip-audit top-up over Group A) |

Plus one first-party source fix:
- **`resources/forms.py`** — Django 4.2 rejects `ClearableFileInput(attrs={'multiple': True})`. Replaced with the documented `MultipleFileInput`/`MultipleFileField` classes (the only first-party 4.2 breakage `manage.py check` found).

## Scope decisions (minimal 4.2, per direction)
- **`django-allauth` and `djangorestframework-simplejwt` are NOT bumped** — they are **not in `INSTALLED_APPS` and have zero first-party imports** (unused deps). Real ORCiD auth is `mozilla-django-oidc`. The allauth security advisories need a **65.x** rewrite; deferred to its own effort (and arguably these unused deps should just be removed — separate cleanup).
- **`django-guardian` left at 2.3.0** — it runs fine on 4.2; its only `makemigrations` drift (BigAutoField `id`) is **pre-existing on 4.1.7** (confirmed against the 1.0.14 image), caused by `DEFAULT_AUTO_FIELD=BigAutoField`, not a 4.2 regression. Bumping to guardian 3.x is a major change for no 4.2 benefit.

## Validation on dev (image 1.0.15, branch deployed, `--migrate`)
- ✅ `manage.py check` — **0 issues** under Django 4.2.30 (built the image, ran check with the repo mounted *before* pushing)
- ✅ `makemigrations --check` — no **new** first-party migrations (only the pre-existing guardian drift)
- ✅ Migrations applied cleanly on deploy — only `authtoken.0004_alter_tokenproxy_options` (DRF 3.15 built-in)
- ✅ Container healthy; `/` `200`, `/atlas/` `200`, `/workbench/` `200`, `/accounts/login/` `200` (OIDC entry)
- ⏳ Full `manage.py test` suite running on dev (results to follow)

## Deploy notes
- Image `1.0.15` built (Group A + Django 4.2) and pushed to Docker Hub; dev's `DOCKER_IMAGE_TAG` set to `1.0.15`, prod stays `1.0.13`.
- Deploy = image rebuild flow (per `build-image.md`) + `--migrate` (the authtoken migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)